### PR TITLE
fix(PassthroughFS): fix invalidate to follow the newest moka

### DIFF
--- a/project/Cargo.lock
+++ b/project/Cargo.lock
@@ -2256,20 +2256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,19 +3554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,23 +3689,22 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "async-lock 3.4.1",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "equivalent",
  "event-listener 5.4.1",
  "futures-util",
- "loom",
  "parking_lot",
  "portable-atomic",
  "rustc_version 0.4.1",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -5490,12 +5462,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/project/libfuse-fs/Cargo.toml
+++ b/project/libfuse-fs/Cargo.toml
@@ -28,5 +28,5 @@ env_logger = "0.11.7"
 vmm-sys-util = "0.12.1"
 bitflags = "2.9.0"
 nix = "0.29.0"
-moka = { version = "0.12.10", features = ["future"] }
+moka = { version = "0.12.11", features = ["future"] }
 memmap2 = "0.9.7"

--- a/project/libfuse-fs/src/passthrough/mod.rs
+++ b/project/libfuse-fs/src/passthrough/mod.rs
@@ -1197,7 +1197,7 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
             .collect();
 
         for item in keys_to_remove {
-            self.mmap_chunks.invalidate(&item.0).await;
+            self.mmap_chunks.invalidate(item.0.as_ref()).await;
         }
     }
 }


### PR DESCRIPTION
Yesterday's update to `moka` changed the signature of `invalidate`, breaking the `libfuse` compilation.