### PR TITLE
build: sync upstream prelude changes from Buck2

### DIFF
--- a/buckal/cargo_buildscript.bzl
+++ b/buckal/cargo_buildscript.bzl
@@ -84,7 +84,7 @@ def _make_rustc_shim(ctx: AnalysisContext, cwd: Artifact) -> cmd_args:
         sysroot_args = cmd_args()
 
     shim = cmd_script(
-        ctx = ctx,
+        actions = ctx.actions,
         name = "__rustc_shim",
         cmd = cmd_args(toolchain_info.compiler, sysroot_args, relative_to = cwd),
         language = ctx.attrs._exec_os_type[OsLookup].script,

--- a/project/libipam/BUCK
+++ b/project/libipam/BUCK
@@ -38,25 +38,13 @@ rust_binary(
     ],
 )
 
-cargo.rust_library(
+rust_library(
     name = "liblibipam",
     srcs = [":libipam-vendor"],
     crate = "libipam",
     crate_root = "vendor/src/lib.rs",
     edition = "2024",
-    env = {
-        "CARGO_CRATE_NAME": "libipam",
-        "CARGO_MANIFEST_DIR": "vendor",
-        "CARGO_PKG_AUTHORS": "rk8s-dev team",
-        "CARGO_PKG_DESCRIPTION": "CNI Plugin IPAM",
-        "CARGO_PKG_NAME": "libipam",
-        "CARGO_PKG_REPOSITORY": "https://github.com/r2cn-dev/rk8s/tree/main/project/libipam",
-        "CARGO_PKG_VERSION": "0.1.0",
-        "CARGO_PKG_VERSION_MAJOR": "0",
-        "CARGO_PKG_VERSION_MINOR": "1",
-        "CARGO_PKG_VERSION_PATCH": "0",
-        "CARGO_PKG_VERSION_PRE": "",
-    },
+    rustc_flags = ["@$(location :libipam-manifest[env_flags])"],
     visibility = ["PUBLIC"],
     deps = [
         "//third-party/rust/crates/anyhow/1.0.100:anyhow",


### PR DESCRIPTION
This PR syncs the latest breaking changes (https://github.com/facebook/buck2/commit/579f766ed7480c9be7e3d622d5f986660c20c10a) from the upstream Buck2 repository introduced yesterday, ensuring compatibility with the updated prelude.