### PR TITLE
fix(libfuse): fix flags in `ReplyOpen` & fix `set_creds` logic

### DIFF
--- a/project/libfuse-fs/examples/overlay.rs
+++ b/project/libfuse-fs/examples/overlay.rs
@@ -111,6 +111,17 @@ async fn main() -> Result<(), std::io::Error> {
 
     set_log(&args);
 
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open("/tmp/overlayfs.log")?;
+    use std::os::unix::io::AsRawFd;
+    unsafe {
+        libc::dup2(file.as_raw_fd(), libc::STDOUT_FILENO);
+        libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO);
+    }
+
     let mut mount_handle = libfuse_fs::overlayfs::mount_fs(OverlayArgs {
         name: Some(args.name),
         mountpoint: args.mountpoint,

--- a/project/libfuse-fs/examples/overlayfs_example.rs
+++ b/project/libfuse-fs/examples/overlayfs_example.rs
@@ -21,7 +21,7 @@ struct Args {
     #[arg(long)]
     lowerdir: Vec<String>,
     /// Use privileged mount instead of unprivileged (default false)
-    #[arg(long, default_value_t = true)]
+    #[arg(long, default_value_t = false)]
     privileged: bool,
     /// Options, currently contains uid/gid mapping info
     #[arg(long, short)]


### PR DESCRIPTION
- 在 xfstests 中遇到了 `write` 中无效参数的问题。解决方案是修复 `open()` 调用返回值的 flags，使其在目前的使用方式中不会出现 `O_DIRECT` 标志。这样做的原因是这个标志需要比较复杂的处理逻辑，目前还未实现（参考了上游仓库 fuse-backend-rs 也没有实现），所以暂时不要返回这个 flag
- 在挂载后进行 buck2 构建时发现了一个此前 uid/gid mapping 中引入的 bug：代码顺序没有调整好，在切换线程 uid/gid 后（例如切换到普通用户身份）还进行了 `open_by_handle_at()` 调用，它需要 `CAP_DAC_READ_SEARCH` 能力，而这通常是 root 用户才有的。解决方案是把需要 root 能力的调用调整到线程 uid/gid 切换之前执行