### PR TITLE
feat(slayerfs):Add distributed testing scripts and configuration for SlayerFS

### DIFF
--- a/project/slayerfs/.gitignore
+++ b/project/slayerfs/.gitignore
@@ -1,1 +1,3 @@
 slayerfs-meta/
+*.env
+results/

--- a/project/slayerfs/tests/scripts/distributed-tests/cluster.env.example
+++ b/project/slayerfs/tests/scripts/distributed-tests/cluster.env.example
@@ -1,0 +1,68 @@
+# Example configuration for distributed SlayerFS tests.
+# Copy to scripts/distributed-tests/cluster.env and adjust for your environment.
+
+# Cluster topology
+CLUSTER_NODES="node-a node-b node-c"
+CLIENT_NODES="node-a node-b"
+META_NODES="node-a"
+PRIMARY_CLIENT="node-a"
+
+# SSH settings
+SSH_USER="ubuntu"
+SSH_KEY="$HOME/.ssh/id_rsa"
+SSH_PORT=22
+SSH_OPTS="-o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+REMOTE_SUDO="sudo -n"  # Use "sudo" if passwordless sudo is not configured
+
+# Remote directories
+REMOTE_WORKDIR="/tmp/slayerfs-dist"
+REMOTE_RESULTS_DIR="/tmp/slayerfs-results"
+
+# Local results directory (relative to repo root or absolute)
+RESULTS_DIR="./results"
+
+# SlayerFS deployment
+SLAYERFS_BUILD=1
+SLAYERFS_EXAMPLE="persistence_demo"
+SLAYERFS_META_BACKEND="etcd"            # etcd | redis | postgres | sqlite
+SLAYERFS_META_ETCD_URLS="http://node-a:2379,http://node-b:2379,http://node-c:2379"
+SLAYERFS_META_URL="redis://node-a:6379/1"
+SLAYERFS_CONFIG_REMOTE="$REMOTE_WORKDIR/slayerfs.yml"
+SLAYERFS_MOUNT_DIR="/mnt/slayerfs"
+SLAYERFS_META_DIR="/var/lib/slayerfs/meta"
+SLAYERFS_DATA_DIR="/var/lib/slayerfs/data"
+SLAYERFS_LOG_DIR="/var/log/slayerfs"
+ETCD_DATA_DIR="/var/lib/etcd"
+ETCD_LOG_FILE="/tmp/etcd.log"
+
+# Workload toggles
+RUN_FIO=1
+RUN_MDTEST=1
+RUN_IOZONE=0
+RUN_XFSTESTS=0
+TEST_PROGRESS_INTERVAL=10
+
+# fio settings
+FIO_RUNTIME=60
+FIO_SIZE="20G"
+FIO_NUMJOBS=4
+FIO_IODEPTH=16
+FIO_BS_SEQ="1M"
+FIO_BS_RAND="4K"
+FIO_RWMIXREAD=70
+FIO_DIRECT=0
+
+# mdtest settings (use MDTEST_ARGS to override)
+MDTEST_NFILES=10000
+MDTEST_NPROCS=4
+
+# Cleanup settings
+CLEANUP_DATA=0  # Set to 1 to also clean etcd metadata and data directories on cleanup
+
+# iozone settings
+IOZONE_SIZE="1G"           # Test file size
+# IOZONE_ARGS="-a -A -r 4k -i 1m -s ${IOZONE_SIZE}"  # Auto mode (custom args override defaults)
+
+# xfstests settings
+XFSTESTS_DIR="/opt/xfstests"
+XFSTESTS_ARGS="-g quick"

--- a/project/slayerfs/tests/scripts/distributed-tests/lib/common.sh
+++ b/project/slayerfs/tests/scripts/distributed-tests/lib/common.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+log_info() {
+  printf '[INFO] %s\n' "$*"
+}
+
+log_warn() {
+  printf '[WARN] %s\n' "$*"
+}
+
+log_error() {
+  printf '[ERROR] %s\n' "$*" >&2
+}
+
+log_success() {
+  printf '[OK] %s\n' "$*"
+}
+
+die() {
+  log_error "$*"
+  exit 1
+}
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    die "Missing required config: ${name}"
+  fi
+}
+
+ensure_dir() {
+  local path="$1"
+  if [[ -z "$path" ]]; then
+    die "ensure_dir called with empty path"
+  fi
+  mkdir -p "$path"
+}
+
+now_stamp() {
+  date '+%Y%m%d-%H%M%S'
+}

--- a/project/slayerfs/tests/scripts/distributed-tests/lib/slayerfs.sh
+++ b/project/slayerfs/tests/scripts/distributed-tests/lib/slayerfs.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+slayerfs_local_binary() {
+  local repo_root="$1"
+  if [[ -n "${SLAYERFS_BIN_LOCAL:-}" ]]; then
+    printf '%s' "$SLAYERFS_BIN_LOCAL"
+    return 0
+  fi
+  printf '%s' "${repo_root}/target/release/examples/${SLAYERFS_EXAMPLE}"
+}
+
+slayerfs_build_local() {
+  local repo_root="$1"
+  log_info "Building SlayerFS example: ${SLAYERFS_EXAMPLE}"
+  (cd "${repo_root}" && cargo build -p slayerfs --example "${SLAYERFS_EXAMPLE}" --release)
+}
+
+slayerfs_etcd_urls_csv() {
+  if [[ -n "${SLAYERFS_META_ETCD_URLS:-}" ]]; then
+    printf '%s' "$SLAYERFS_META_ETCD_URLS"
+    return 0
+  fi
+
+  if [[ -n "${META_NODES:-}" ]]; then
+    local urls=()
+    local node
+    for node in $META_NODES; do
+      urls+=("http://${node}:2379")
+    done
+    (IFS=','; printf '%s' "${urls[*]}")
+    return 0
+  fi
+
+  die "SLAYERFS_META_ETCD_URLS or META_NODES must be set for etcd backend"
+}
+
+slayerfs_render_config() {
+  local backend="${SLAYERFS_META_BACKEND}"
+
+  case "$backend" in
+    etcd)
+      local urls_csv
+      urls_csv="$(slayerfs_etcd_urls_csv)"
+      local urls=()
+      IFS=',' read -r -a urls <<< "$urls_csv"
+      printf 'database:\n'
+      printf '  type: etcd\n'
+      printf '  urls:\n'
+      local url
+      for url in "${urls[@]}"; do
+        printf '    - "%s"\n' "$url"
+      done
+      ;;
+    redis)
+      require_var SLAYERFS_META_URL
+      printf 'database:\n'
+      printf '  type: redis\n'
+      printf '  url: "%s"\n' "$SLAYERFS_META_URL"
+      ;;
+    postgres)
+      require_var SLAYERFS_META_URL
+      printf 'database:\n'
+      printf '  type: postgres\n'
+      printf '  url: "%s"\n' "$SLAYERFS_META_URL"
+      ;;
+    sqlite)
+      require_var SLAYERFS_META_URL
+      printf 'database:\n'
+      printf '  type: sqlite\n'
+      printf '  url: "%s"\n' "$SLAYERFS_META_URL"
+      ;;
+    *)
+      die "Unknown SLAYERFS_META_BACKEND: ${backend}"
+      ;;
+  esac
+}
+
+slayerfs_prepare_node() {
+  local node="$1"
+
+  # Clean up stale mount points before preparing
+  log_info "  Cleaning up stale mount point on ${node}"
+  ssh_exec_sudo "$node" "umount -l '${SLAYERFS_MOUNT_DIR}' 2>/dev/null || fusermount -u '${SLAYERFS_MOUNT_DIR}' 2>/dev/null || true"
+  ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_MOUNT_DIR}' 2>/dev/null || true"
+
+  ssh_exec_sudo "$node" "mkdir -p '${REMOTE_WORKDIR}/bin' '${REMOTE_WORKDIR}/pids' '${SLAYERFS_META_DIR}' '${SLAYERFS_DATA_DIR}' '${SLAYERFS_MOUNT_DIR}' '${SLAYERFS_LOG_DIR}'"
+  ssh_exec_sudo "$node" "chown -R '${SSH_USER}':'${SSH_USER}' '${REMOTE_WORKDIR}' '${SLAYERFS_META_DIR}' '${SLAYERFS_DATA_DIR}' '${SLAYERFS_MOUNT_DIR}' '${SLAYERFS_LOG_DIR}'"
+
+  # Enable user_allow_other in /etc/fuse.conf for allow_other mount option
+  log_info "  Enabling user_allow_other in /etc/fuse.conf on ${node}"
+  ssh_exec_sudo "$node" "grep -q '^user_allow_other' /etc/fuse.conf 2>/dev/null || echo 'user_allow_other' >> /etc/fuse.conf"
+}
+
+slayerfs_deploy_binary() {
+  local node="$1"
+  local bin_local="$2"
+  local bin_remote="${REMOTE_WORKDIR}/bin/slayerfs-demo"
+
+  local local_md5
+  local_md5=$(md5sum "$bin_local" 2>/dev/null | awk '{print $1}')
+
+  if [[ -z "$local_md5" ]]; then
+    log_warn "Failed to compute local MD5, uploading without check"
+    scp_to "$bin_local" "$node" "$bin_remote"
+    ssh_exec "$node" "chmod +x '$bin_remote'"
+    SLAYERFS_BIN_REMOTE="$bin_remote"
+    return 0
+  fi
+
+  # Check if remote file exists and has the same MD5
+  if ssh_run "$node" "test -f '$bin_remote' && md5sum '$bin_remote' 2>/dev/null | awk '{print \$1}' | grep -q '$local_md5'"; then
+    log_info "Binary already exists on ${node} (MD5: ${local_md5}), skipping upload"
+    SLAYERFS_BIN_REMOTE="$bin_remote"
+    return 0
+  fi
+
+  # Need to upload
+  log_info "Uploading binary to ${node}..."
+  scp_to "$bin_local" "$node" "$bin_remote"
+  ssh_exec "$node" "chmod +x '$bin_remote'"
+  SLAYERFS_BIN_REMOTE="$bin_remote"
+}
+
+slayerfs_deploy_config() {
+  local node="$1"
+  local cfg_remote="${SLAYERFS_CONFIG_REMOTE:-${REMOTE_WORKDIR}/slayerfs.yml}"
+
+  local cfg_basename
+  cfg_basename="$(basename "$cfg_remote")"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  local tmp_cfg="${tmp_dir}/${cfg_basename}"
+  slayerfs_render_config > "$tmp_cfg"
+  scp_to "$tmp_cfg" "$node" "$cfg_remote"
+  rm -rf "$tmp_dir"
+
+  SLAYERFS_CONFIG_REMOTE="$cfg_remote"
+}
+
+slayerfs_start_node() {
+  local node="$1"
+  local bin_remote="${SLAYERFS_BIN_REMOTE}"
+  local cfg_remote="${SLAYERFS_CONFIG_REMOTE}"
+  local log_file="${SLAYERFS_LOG_DIR}/slayerfs-${node}.log"
+  local pid_file="${REMOTE_WORKDIR}/pids/slayerfs-${node}.pid"
+
+  local cmd
+  cmd="'${bin_remote}' --config '${cfg_remote}' --mount '${SLAYERFS_MOUNT_DIR}' --storage '${SLAYERFS_DATA_DIR}'"
+
+  ssh_exec "$node" "nohup bash -lc \"${cmd}\" >'${log_file}' 2>&1 & echo \$! > '${pid_file}'"
+}
+
+slayerfs_wait_mount() {
+  local node="$1"
+  local mount_dir="$SLAYERFS_MOUNT_DIR"
+  local retries="${MOUNT_WAIT_RETRIES:-30}"
+
+  ssh_run "$node" "for i in \$(seq 1 ${retries}); do if command -v mountpoint >/dev/null 2>&1; then mountpoint -q '${mount_dir}' && exit 0; else mount | grep -q ' ${mount_dir} ' && exit 0; fi; sleep 1; done; exit 1"
+}
+
+slayerfs_stop_node() {
+  local node="$1"
+  local pid_file="${REMOTE_WORKDIR}/pids/slayerfs-${node}.pid"
+
+  ssh_exec "$node" "if [[ -f '${pid_file}' ]]; then kill \$(cat '${pid_file}') >/dev/null 2>&1 || true; fi"
+}
+
+slayerfs_unmount_node() {
+  local node="$1"
+  # First, try to unmount if mounted
+  ssh_exec_sudo "$node" "if mountpoint -q '${SLAYERFS_MOUNT_DIR}'; then fusermount -u '${SLAYERFS_MOUNT_DIR}' || umount -f '${SLAYERFS_MOUNT_DIR}'; fi"
+  # Then, clean up any leftover files in the mount directory
+  ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_MOUNT_DIR}'/* 2>/dev/null || true"
+}

--- a/project/slayerfs/tests/scripts/distributed-tests/lib/ssh.sh
+++ b/project/slayerfs/tests/scripts/distributed-tests/lib/ssh.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+ssh_exec() {
+  local node="$1"
+  shift
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -p "${SSH_PORT:-22}" )
+
+  ssh "${opts[@]}" "${SSH_USER}@${node}" "$@"
+}
+
+ssh_run() {
+  local node="$1"
+  shift
+  local cmd="$*"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -p "${SSH_PORT:-22}" )
+
+  printf '%s\n' "$cmd" | ssh "${opts[@]}" "${SSH_USER}@${node}" "bash -s"
+}
+
+ssh_exec_sudo() {
+  local node="$1"
+  shift
+  local cmd="$*"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -p "${SSH_PORT:-22}" )
+
+  local sudo_parts=()
+  read -r -a sudo_parts <<< "${REMOTE_SUDO:-sudo}"
+
+  printf '%s\n' "$cmd" | ssh "${opts[@]}" "${SSH_USER}@${node}" "${sudo_parts[@]}" "bash -s"
+}
+
+scp_to() {
+  local src="$1"
+  local node="$2"
+  local dest="$3"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -P "${SSH_PORT:-22}" )
+
+  scp "${opts[@]}" "$src" "${SSH_USER}@${node}:$dest"
+}
+
+scp_to_dir() {
+  local src="$1"
+  local node="$2"
+  local dest="$3"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -P "${SSH_PORT:-22}" -r )
+
+  scp "${opts[@]}" "$src" "${SSH_USER}@${node}:$dest"
+}
+
+scp_from() {
+  local node="$1"
+  local src="$2"
+  local dest="$3"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -P "${SSH_PORT:-22}" )
+
+  scp "${opts[@]}" "${SSH_USER}@${node}:$src" "$dest"
+}
+
+scp_from_dir() {
+  local node="$1"
+  local src="$2"
+  local dest="$3"
+
+  local opts=()
+  if [[ -n "${SSH_OPTS:-}" ]]; then
+    read -r -a opts <<< "${SSH_OPTS}"
+  fi
+  if [[ -n "${SSH_KEY:-}" ]]; then
+    opts+=( -i "${SSH_KEY}" )
+  fi
+  opts+=( -P "${SSH_PORT:-22}" -r )
+
+  scp "${opts[@]}" "${SSH_USER}@${node}:$src" "$dest"
+}

--- a/project/slayerfs/tests/scripts/distributed-tests/lib/tests.sh
+++ b/project/slayerfs/tests/scripts/distributed-tests/lib/tests.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+
+remote_results_root() {
+  local fs_name="$1"
+  printf '%s/%s/%s' "${REMOTE_RESULTS_DIR}" "${RUN_ID}" "$fs_name"
+}
+
+run_with_progress() {
+  local node="$1"
+  local label="$2"
+  local cmd="$3"
+  local interval="${TEST_PROGRESS_INTERVAL:-10}"
+  local start
+  start=$(date +%s)
+
+  log_info "Start ${label}"
+  ssh_run "$node" "$cmd" &
+  local pid=$!
+
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep "$interval"
+    if kill -0 "$pid" 2>/dev/null; then
+      local now elapsed
+      now=$(date +%s)
+      elapsed=$((now - start))
+      log_info "  ${label} running... ${elapsed}s elapsed"
+    fi
+  done
+
+  wait "$pid"
+  local status=$?
+  local end elapsed
+  end=$(date +%s)
+  elapsed=$((end - start))
+  if [[ $status -eq 0 ]]; then
+    log_success "Done ${label} in ${elapsed}s"
+  else
+    log_error "Failed ${label} after ${elapsed}s (exit ${status})"
+    return "$status"
+  fi
+}
+
+run_fio() {
+  local fs_name="$1"
+  local mount_dir="$2"
+
+  if ! ssh_run "$PRIMARY_CLIENT" "command -v fio >/dev/null 2>&1"; then
+    log_warn "fio not found on ${PRIMARY_CLIENT}; skipping"
+    return 0
+  fi
+
+  local out_dir
+  out_dir="$(remote_results_root "$fs_name")/fio"
+
+  ssh_run "$PRIMARY_CLIENT" "mkdir -p '${out_dir}'"
+
+  local common="--ioengine=libaio --direct=${FIO_DIRECT} --numjobs=${FIO_NUMJOBS} --iodepth=${FIO_IODEPTH} --time_based --runtime=${FIO_RUNTIME} --group_reporting"
+
+  run_with_progress "$PRIMARY_CLIENT" "fio (1/4) seqwrite" "sudo fio --name=seqwrite --directory='${mount_dir}' --rw=write --bs='${FIO_BS_SEQ}' --size='${FIO_SIZE}' ${common} --output-format=json --output='${out_dir}/seqwrite.json'"
+  run_with_progress "$PRIMARY_CLIENT" "fio (2/4) seqread" "sudo fio --name=seqwrite --directory='${mount_dir}' --rw=read --bs='${FIO_BS_SEQ}' ${common} --output-format=json --output='${out_dir}/seqread.json'"
+  run_with_progress "$PRIMARY_CLIENT" "fio (3/4) randwrite" "sudo fio --name=randwrite --directory='${mount_dir}' --rw=randwrite --bs='${FIO_BS_RAND}' --size='${FIO_SIZE}' ${common} --output-format=json --output='${out_dir}/randwrite.json'"
+  run_with_progress "$PRIMARY_CLIENT" "fio (4/4) randread" "sudo fio --name=randwrite --directory='${mount_dir}' --rw=randread --bs='${FIO_BS_RAND}' ${common} --output-format=json --output='${out_dir}/randread.json'"
+  }
+
+run_mdtest() {
+  local fs_name="$1"
+  local mount_dir="$2"
+
+  if ! ssh_run "$PRIMARY_CLIENT" "command -v mdtest >/dev/null 2>&1"; then
+    log_warn "mdtest not found on ${PRIMARY_CLIENT}; skipping"
+    return 0
+  fi
+
+  local out_dir
+  out_dir="$(remote_results_root "$fs_name")/mdtest"
+
+  ssh_run "$PRIMARY_CLIENT" "mkdir -p '${out_dir}'"
+
+  local mdtest_dir="${mount_dir}/mdtest-${RUN_ID}"
+  local cmd
+  if [[ -n "${MDTEST_ARGS:-}" ]]; then
+    cmd="mdtest ${MDTEST_ARGS} -d '${mdtest_dir}'"
+  else
+    cmd="mdtest -d '${mdtest_dir}' -n ${MDTEST_NFILES} -u -t -F -C -T -r -W -e -p ${MDTEST_NPROCS}"
+  fi
+
+  run_with_progress "$PRIMARY_CLIENT" "mdtest" "sudo ${cmd} | tee '${out_dir}/mdtest.log'"
+  ssh_run "$PRIMARY_CLIENT" "sudo rm -rf '${mdtest_dir}'"
+}
+
+run_iozone() {
+  local fs_name="$1"
+  local mount_dir="$2"
+
+  if ! ssh_run "$PRIMARY_CLIENT" "command -v iozone >/dev/null 2>&1"; then
+    log_error "iozone not found. Please install iozone manually or set RUN_IOZONE=0"
+    die "Required dependency missing: iozone"
+  fi
+
+  local out_dir
+  out_dir="$(remote_results_root "$fs_name")/iozone"
+
+  ssh_run "$PRIMARY_CLIENT" "mkdir -p '${out_dir}'"
+
+  local iozone_dir="${mount_dir}/iozone-${RUN_ID}"
+  local iozone_size="${IOZONE_SIZE:-10G}"
+  local iozone_file="${iozone_dir}/iozone.file"
+
+  ssh_exec_sudo "$PRIMARY_CLIENT" "mkdir -p '${iozone_dir}'"
+
+  # IOzone test parameters
+  local cmd
+  if [[ -n "${IOZONE_ARGS:-}" ]]; then
+    cmd="sudo iozone ${IOZONE_ARGS} -f ${iozone_file} 2>&1 | tee '${out_dir}/iozone.log'"
+  else
+    # Default: automatic mode with 10G file, 1M record size, 4K to 1M mix
+    cmd="sudo iozone -a -A -r 4k -i 1m -s ${iozone_size} -f ${iozone_file} 2>&1 | tee '${out_dir}/iozone.log'"
+  fi
+
+  run_with_progress "$PRIMARY_CLIENT" "iozone" "${cmd}"
+  ssh_exec_sudo "$PRIMARY_CLIENT" "rm -rf '${iozone_dir}'"
+}
+
+run_xfstests() {
+  local fs_name="$1"
+  local mount_dir="$2"
+
+  if [[ -z "${XFSTESTS_DIR:-}" ]]; then
+    log_warn "XFSTESTS_DIR not set; skipping"
+    return 0
+  fi
+
+  # Auto-install xfstests if not found
+  if ! ssh_run "$PRIMARY_CLIENT" "test -d '${XFSTESTS_DIR}'"; then
+    log_info "xfstests not found, installing on ${PRIMARY_CLIENT}..."
+
+    log_info "  Installing xfstests dependencies..."
+    ssh_exec_sudo "$PRIMARY_CLIENT" "apt-get update && apt-get install -y acl attr automake bc dbench dump e2fsprogs fio gawk gcc git libacl1-dev libaio-dev libcap-dev libgdbm-dev libtool libtool-bin liburing-dev libuuid1 lvm2 make psmisc python3 quota sed uuid-dev uuid-runtime xfsprogs linux-headers-$(uname -r) sqlite3 fuse3" || return 1
+
+    log_info "  Cloning xfstests..."
+    ssh_exec_sudo "$PRIMARY_CLIENT" "rm -rf /tmp/xfstests-dev && git clone -b v2023.12.10 git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git /tmp/xfstests-dev" || return 1
+
+    log_info "  Building xfstests..."
+    ssh_exec_sudo "$PRIMARY_CLIENT" "cd /tmp/xfstests-dev && make && sudo make install" || return 1
+
+    # Create XFSTESTS_DIR if custom path was specified
+    if [[ "${XFSTESTS_DIR}" != "/tmp/xfstests-dev" ]]; then
+      ssh_exec_sudo "$PRIMARY_CLIENT" "mkdir -p '${XFSTESTS_DIR}'"
+    fi
+
+    log_success "xfstests installed"
+  fi
+
+  local out_dir
+  out_dir="$(remote_results_root "$fs_name")/xfstests"
+  ssh_run "$PRIMARY_CLIENT" "mkdir -p '${out_dir}'"
+
+  # Copy exclude file if exists
+  local exclude_file="${SCRIPT_DIR}/../xfstests_slayer.exclude"
+  if [[ -f "$exclude_file" ]]; then
+    log_info "  Copying xfstests exclude file..."
+    scp_to "$PRIMARY_CLIENT" "$exclude_file" "/tmp/xfstests_slayer.exclude"
+  fi
+
+  if [[ -n "${XFSTESTS_CMD:-}" ]]; then
+    run_with_progress "$PRIMARY_CLIENT" "xfstests" "cd '${XFSTESTS_DIR}' && ${XFSTESTS_CMD} | tee '${out_dir}/xfstests.log'"
+    return 0
+  fi
+
+  local fuse_subtyp="${XFSTESTS_FUSE_SUBTYP:-.slayerfs}"
+  local cmd
+  cmd="cd '${XFSTESTS_DIR}' && TEST_DIR='${mount_dir}' TEST_DEV='${fs_name}' FSTYP=fuse FUSE_SUBTYP='${fuse_subtyp}' DF_PROG='df -T -P -a' ./check ${XFSTESTS_ARGS}"
+
+  if [[ -f "$exclude_file" ]]; then
+    cmd+=" -E xfstests_slayer.exclude"
+  fi
+
+  run_with_progress "$PRIMARY_CLIENT" "xfstests" "${cmd} | tee '${out_dir}/xfstests.log'"
+}
+
+run_tests_for_fs() {
+  local fs_name="$1"
+  local mount_dir="$2"
+
+  if [[ "${RUN_FIO:-0}" == "1" ]]; then
+    run_fio "$fs_name" "$mount_dir"
+  fi
+
+  if [[ "${RUN_MDTEST:-0}" == "1" ]]; then
+    run_mdtest "$fs_name" "$mount_dir"
+  fi
+
+  if [[ "${RUN_IOZONE:-0}" == "1" ]]; then
+    run_iozone "$fs_name" "$mount_dir"
+  fi
+
+  if [[ "${RUN_XFSTESTS:-0}" == "1" ]]; then
+    run_xfstests "$fs_name" "$mount_dir"
+  fi
+
+}

--- a/project/slayerfs/tests/scripts/distributed-tests/run-distributed-tests.sh
+++ b/project/slayerfs/tests/scripts/distributed-tests/run-distributed-tests.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(realpath "${SCRIPT_DIR}/../../../..")"
+
+source "${SCRIPT_DIR}/lib/common.sh"
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} [options] <action>
+
+Actions:
+  prepare           Prepare local/remote directories
+  deploy-slayerfs   Build (optional) and deploy SlayerFS to client nodes
+  test-slayerfs     Run workloads on SlayerFS mount
+  collect           Pull remote results to local results dir
+  cleanup           Stop mounts and background processes
+  all               Run prepare + deploy + test + collect
+
+Options:
+  -c, --config PATH   Path to cluster.env (default: SCRIPT_DIR/cluster.env)
+  -h, --help          Show this help
+USAGE
+}
+
+ACTION="all"
+CONFIG_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c|--config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ACTION="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$CONFIG_PATH" ]]; then
+  CONFIG_PATH="${SCRIPT_DIR}/cluster.env"
+fi
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  die "Config not found: ${CONFIG_PATH} (copy cluster.env.example to cluster.env)"
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$CONFIG_PATH"
+set +a
+
+source "${SCRIPT_DIR}/lib/ssh.sh"
+source "${SCRIPT_DIR}/lib/slayerfs.sh"
+source "${SCRIPT_DIR}/lib/tests.sh"
+
+CLUSTER_NODES="${CLUSTER_NODES:-}"
+CLIENT_NODES="${CLIENT_NODES:-$CLUSTER_NODES}"
+META_NODES="${META_NODES:-$CLUSTER_NODES}"
+PRIMARY_CLIENT="${PRIMARY_CLIENT:-${CLIENT_NODES%% *}}"
+
+SSH_PORT="${SSH_PORT:-22}"
+REMOTE_SUDO="${REMOTE_SUDO:-sudo -n}"
+REMOTE_WORKDIR="${REMOTE_WORKDIR:-/tmp/slayerfs-dist}"
+REMOTE_RESULTS_DIR="${REMOTE_RESULTS_DIR:-/tmp/slayerfs-results}"
+RESULTS_DIR="${RESULTS_DIR:-${SCRIPT_DIR}/results}"
+
+SLAYERFS_BUILD="${SLAYERFS_BUILD:-0}"
+SLAYERFS_EXAMPLE="${SLAYERFS_EXAMPLE:-persistence_demo}"
+SLAYERFS_META_BACKEND="${SLAYERFS_META_BACKEND:-etcd}"
+SLAYERFS_CONFIG_REMOTE="${SLAYERFS_CONFIG_REMOTE:-${REMOTE_WORKDIR}/slayerfs.yml}"
+SLAYERFS_MOUNT_DIR="${SLAYERFS_MOUNT_DIR:-/mnt/slayerfs}"
+SLAYERFS_META_DIR="${SLAYERFS_META_DIR:-/var/lib/slayerfs/meta}"
+SLAYERFS_DATA_DIR="${SLAYERFS_DATA_DIR:-/var/lib/slayerfs/data}"
+SLAYERFS_LOG_DIR="${SLAYERFS_LOG_DIR:-/var/log/slayerfs}"
+
+ETCD_DATA_DIR="${ETCD_DATA_DIR:-/var/lib/etcd}"
+ETCD_LOG_FILE="${ETCD_LOG_FILE:-/tmp/etcd.log}"
+if [[ -z "${ETCD_DATA_DIR// }" ]]; then
+  ETCD_DATA_DIR="/var/lib/etcd"
+fi
+if [[ -z "${ETCD_LOG_FILE// }" ]]; then
+  ETCD_LOG_FILE="/tmp/etcd.log"
+fi
+
+RUN_ID="${RUN_ID:-$(now_stamp)}"
+export RUN_ID
+
+FIO_RUNTIME="${FIO_RUNTIME:-60}"
+FIO_SIZE="${FIO_SIZE:-20G}"
+FIO_NUMJOBS="${FIO_NUMJOBS:-4}"
+FIO_IODEPTH="${FIO_IODEPTH:-16}"
+FIO_BS_SEQ="${FIO_BS_SEQ:-1M}"
+FIO_BS_RAND="${FIO_BS_RAND:-4K}"
+FIO_RWMIXREAD="${FIO_RWMIXREAD:-70}"
+FIO_DIRECT="${FIO_DIRECT:-0}"
+
+MDTEST_NFILES="${MDTEST_NFILES:-10000}"
+MDTEST_NPROCS="${MDTEST_NPROCS:-4}"
+
+require_var SSH_USER
+require_var CLUSTER_NODES
+require_var PRIMARY_CLIENT
+
+check_dependencies() {
+  log_info "Checking dependencies..."
+
+  # Check SSH connectivity and sudo
+  for node in $CLIENT_NODES; do
+    if ! ssh_exec "$node" "echo 'SSH OK'" >/dev/null 2>&1; then
+      die "SSH connection failed to ${node}"
+    fi
+    if ! ssh_exec_sudo "$node" "true" >/dev/null 2>&1; then
+      die "Passwordless sudo not configured on ${node} (set REMOTE_SUDO='sudo' if using password)"
+    fi
+  done
+  log_success "SSH and sudo: OK"
+
+  # Check/install fio if enabled
+  if [[ "${RUN_FIO:-0}" == "1" ]]; then
+    if ! ssh_run "$PRIMARY_CLIENT" "command -v fio >/dev/null 2>&1"; then
+      log_warn "fio not found, installing on all CLIENT_NODES..."
+      for node in $CLIENT_NODES; do
+        log_info "  Installing fio on ${node}..."
+        ssh_exec_sudo "$node" "apt-get update && apt-get install -y fio"
+      done
+    fi
+    log_success "fio: OK"
+  fi
+
+  # Check mdtest if enabled
+  if [[ "${RUN_MDTEST:-0}" == "1" ]]; then
+    if ! ssh_run "$PRIMARY_CLIENT" "command -v mdtest >/dev/null 2>&1"; then
+      log_error "mdtest not found. Please install mdtest manually or set RUN_MDTEST=0"
+      die "Required dependency missing: mdtest"
+    fi
+    log_success "mdtest: OK"
+  fi
+}
+
+prepare() {
+  log_info "Preparing environment"
+
+  check_dependencies
+
+  # Create remote work directories (not RUN_ID specific)
+  for node in $CLIENT_NODES; do
+    ssh_exec "$node" "mkdir -p '${REMOTE_WORKDIR}'"
+  done
+  log_success "Environment prepared"
+}
+
+deploy_slayerfs() {
+  if [[ "${SLAYERFS_BUILD}" == "1" ]]; then
+    slayerfs_build_local "${REPO_ROOT}"
+  fi
+
+  local bin_local
+  bin_local="$(slayerfs_local_binary "${REPO_ROOT}")"
+  if [[ ! -f "$bin_local" ]]; then
+    die "SlayerFS binary not found: ${bin_local}"
+  fi
+
+  for node in $CLIENT_NODES; do
+    log_info "Deploy SlayerFS to ${node}"
+    slayerfs_prepare_node "$node"
+    slayerfs_deploy_binary "$node" "$bin_local"
+    slayerfs_deploy_config "$node"
+    slayerfs_start_node "$node"
+  done
+
+  for node in $CLIENT_NODES; do
+    log_info "Wait for SlayerFS mount on ${node}"
+    slayerfs_wait_mount "$node"
+  done
+  log_success "SlayerFS deployed"
+}
+
+test_slayerfs() {
+  log_info "Run workloads on SlayerFS"
+
+  # Check if SlayerFS is mounted on primary client
+  if ! ssh_run "$PRIMARY_CLIENT" "mountpoint -q '${SLAYERFS_MOUNT_DIR}'"; then
+    log_error "SlayerFS is not mounted on ${PRIMARY_CLIENT}. Please run 'deploy-slayerfs' first."
+    return 1
+  fi
+
+  # Create remote test result directory with current RUN_ID
+  log_info "Creating test result directory: ${RUN_ID}"
+  for node in $CLIENT_NODES; do
+    ssh_exec "$node" "mkdir -p '${REMOTE_RESULTS_DIR}/${RUN_ID}'"
+  done
+
+  # Run tests
+  run_tests_for_fs "slayerfs" "${SLAYERFS_MOUNT_DIR}"
+
+  # Display completion message with RUN_ID
+  echo ""
+  echo "========================================"
+  log_success "SlayerFS tests completed!"
+  echo "RUN_ID: ${RUN_ID}"
+  echo ""
+  echo "To collect results, run:"
+  echo "  ./run-distributed-tests.sh collect"
+  echo "========================================"
+  echo ""
+}
+
+collect_results() {
+  # Auto-detect: find the latest directory based on enabled tests
+  local remote_run_id
+  local test_pattern=""
+
+  # Build search pattern based on enabled tests
+  if [[ "${RUN_FIO:-0}" == "1" ]]; then
+    test_pattern="${test_pattern}|fio"
+  fi
+  if [[ "${RUN_MDTEST:-0}" == "1" ]]; then
+    test_pattern="${test_pattern}|mdtest"
+  fi
+  if [[ "${RUN_IOZONE:-0}" == "1" ]]; then
+    test_pattern="${test_pattern}|iozone"
+  fi
+  if [[ "${RUN_XFSTESTS:-0}" == "1" ]]; then
+    test_pattern="${test_pattern}|xfstests"
+  fi
+
+  # Remove leading pipe
+  test_pattern="${test_pattern#|}"
+
+  # If no tests enabled, fall back to latest directory
+  if [[ -z "$test_pattern" ]]; then
+    log_warn "No tests enabled in config, using latest directory"
+    remote_run_id=$(ssh_run "$PRIMARY_CLIENT" "ls -t '${REMOTE_RESULTS_DIR}' 2>/dev/null | head -1" | tr -d '\n\r')
+  else
+    remote_run_id=$(ssh_run "$PRIMARY_CLIENT" "
+      for dir in \$(ls -t '${REMOTE_RESULTS_DIR}' 2>/dev/null); do
+        if find '${REMOTE_RESULTS_DIR}'/\${dir}/slayerfs/ -type d 2>/dev/null | egrep -q '(${test_pattern})'; then
+          echo \"\${dir}\"
+          break
+        fi
+      done
+    " | tr -d '\n\r')
+  fi
+
+  if [[ -z "$remote_run_id" ]]; then
+    log_error "No test results found on ${PRIMARY_CLIENT}"
+    log_info "Available directories:"
+    ssh_run "$PRIMARY_CLIENT" "ls -lt '${REMOTE_RESULTS_DIR}'" 2>/dev/null || true
+    return 1
+  fi
+
+  log_info "Auto-detected run-id: ${remote_run_id}"
+
+  local local_dir="${RESULTS_DIR}/${remote_run_id}"
+  ensure_dir "$local_dir"
+
+  # Copy cluster config
+  cp "${CONFIG_PATH}" "${local_dir}/cluster.env"
+
+  # Collect test results from primary client based on enabled tests
+  log_info "Collecting test results from ${PRIMARY_CLIENT}"
+  ensure_dir "${local_dir}/slayerfs"
+
+  if [[ "${RUN_FIO:-0}" == "1" ]]; then
+    scp_from_dir "$PRIMARY_CLIENT" "${REMOTE_RESULTS_DIR}/${remote_run_id}/slayerfs/fio" "${local_dir}/slayerfs/" 2>/dev/null || log_warn "Failed to pull fio results from ${PRIMARY_CLIENT}"
+  fi
+  if [[ "${RUN_MDTEST:-0}" == "1" ]]; then
+    scp_from_dir "$PRIMARY_CLIENT" "${REMOTE_RESULTS_DIR}/${remote_run_id}/slayerfs/mdtest" "${local_dir}/slayerfs/" 2>/dev/null || log_warn "Failed to pull mdtest results from ${PRIMARY_CLIENT}"
+  fi
+  if [[ "${RUN_IOZONE:-0}" == "1" ]]; then
+    scp_from_dir "$PRIMARY_CLIENT" "${REMOTE_RESULTS_DIR}/${remote_run_id}/slayerfs/iozone" "${local_dir}/slayerfs/" 2>/dev/null || log_warn "Failed to pull iozone results from ${PRIMARY_CLIENT}"
+  fi
+  if [[ "${RUN_XFSTESTS:-0}" == "1" ]]; then
+    scp_from_dir "$PRIMARY_CLIENT" "${REMOTE_RESULTS_DIR}/${remote_run_id}/slayerfs/xfstests" "${local_dir}/slayerfs/" 2>/dev/null || log_warn "Failed to pull xfstests results from ${PRIMARY_CLIENT}"
+  fi
+
+  # Collect logs directly from all nodes
+  ensure_dir "${local_dir}/logs"
+  for node in $CLIENT_NODES $META_NODES; do
+    log_info "  Collecting logs from ${node}"
+
+    # Collect SlayerFS logs
+    if [[ -n "${SLAYERFS_LOG_DIR:-}" ]]; then
+      # Get list of log files from remote
+      local log_files
+      log_files=$(ssh_run "$node" "ls '${SLAYERFS_LOG_DIR}'/slayerfs-*.log 2>/dev/null" || true)
+      if [[ -n "$log_files" ]]; then
+        while IFS= read -r log_file; do
+          [[ -z "$log_file" ]] && continue
+          local basename
+          basename=$(basename "$log_file")
+          # Copy to REMOTE_WORKDIR with proper permissions, then scp to local
+          ssh_run "$node" "cp -a '${log_file}' '${REMOTE_WORKDIR}/slayerfs-log-${basename}' && chown '${SSH_USER}' '${REMOTE_WORKDIR}/slayerfs-log-${basename}'"
+          scp_from "$node" "${REMOTE_WORKDIR}/slayerfs-log-${basename}" "${local_dir}/logs/${basename}" 2>/dev/null || true
+          ssh_run "$node" "rm -f '${REMOTE_WORKDIR}/slayerfs-log-${basename}'" 2>/dev/null || true
+        done <<< "$log_files"
+      fi
+    fi
+
+    # Collect etcd logs
+    if [[ "${SLAYERFS_META_BACKEND}" == "etcd" ]] && [[ -n "${ETCD_LOG_FILE:-}" ]]; then
+      if ssh_run "$node" "[[ -f '${ETCD_LOG_FILE}' ]]"; then
+        ssh_run "$node" "cp -a '${ETCD_LOG_FILE}' '${REMOTE_WORKDIR}/etcd.log' && chown '${SSH_USER}' '${REMOTE_WORKDIR}/etcd.log'" 2>/dev/null || true
+        scp_from "$node" "${REMOTE_WORKDIR}/etcd.log" "${local_dir}/logs/etcd-${node}.log" 2>/dev/null || true
+        ssh_run "$node" "rm -f '${REMOTE_WORKDIR}/etcd.log'" 2>/dev/null || true
+      fi
+    fi
+  done
+
+  log_success "Results collected into ${local_dir}"
+}
+
+cleanup() {
+  for node in $CLIENT_NODES; do
+    log_info "Stop SlayerFS on ${node}"
+    slayerfs_stop_node "$node"
+  done
+
+  # Clean up data if CLEANUP_DATA is set
+  if [[ "${CLEANUP_DATA:-0}" == "1" ]]; then
+    log_info "Cleaning up files in SlayerFS mount directories..."
+
+    # Delete files inside /mnt/slayerfs before unmounting
+    for node in $CLIENT_NODES; do
+      log_info "  Cleaning ${SLAYERFS_MOUNT_DIR} on ${node}"
+      ssh_exec_sudo "$node" "find '${SLAYERFS_MOUNT_DIR}' -mindepth 1 -delete 2>/dev/null || true"
+    done
+  fi
+
+  for node in $CLIENT_NODES; do
+    slayerfs_unmount_node "$node"
+  done
+
+  # Clean up data if CLEANUP_DATA is set
+  if [[ "${CLEANUP_DATA:-0}" == "1" ]]; then
+    log_info "Cleaning up SlayerFS data..."
+
+    # Clean etcd metadata
+    if [[ -n "${META_NODES:-}" ]]; then
+      log_info "  Cleaning etcd metadata on META_NODES..."
+      for node in $META_NODES; do
+        ssh_exec "$node" "etcdctl del --prefix 'slayerfs' >/dev/null 2>&1 || true"
+        ssh_exec "$node" "etcdctl del --prefix '/1/' >/dev/null 2>&1 || true"
+        ssh_exec "$node" "etcdctl del --prefix '/slayerfs' >/dev/null 2>&1 || true"
+      done
+    fi
+
+    # Clean data directories on data nodes
+    if [[ -n "${DATA_NODES:-}" ]]; then
+      log_info "  Cleaning data directories on DATA_NODES..."
+      for node in $DATA_NODES; do
+        ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_DATA_DIR}'/* 2>/dev/null || true"
+        ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_META_DIR}'/* 2>/dev/null || true"
+      done
+    fi
+
+    # Clean data directories on client nodes
+    log_info "  Cleaning data directories on CLIENT_NODES..."
+    for node in $CLIENT_NODES; do
+      ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_DATA_DIR}'/* 2>/dev/null || true"
+      ssh_exec_sudo "$node" "rm -rf '${SLAYERFS_META_DIR}'/* 2>/dev/null || true"
+    done
+
+    # Clean remote test results
+    log_info "  Cleaning remote test results..."
+    for node in $CLIENT_NODES; do
+      ssh_exec_sudo "$node" "rm -rf '${REMOTE_RESULTS_DIR}'/* 2>/dev/null || true"
+    done
+
+    # Clean SlayerFS logs
+    if [[ -n "${SLAYERFS_LOG_DIR:-}" ]]; then
+      log_info "  Cleaning SlayerFS logs..."
+      for node in $CLIENT_NODES $META_NODES; do
+        ssh_exec_sudo "$node" "rm -f '${SLAYERFS_LOG_DIR}'/slayerfs-*.log 2>/dev/null || true"
+      done
+    fi
+
+    # Clean etcd logs
+    if [[ -n "${ETCD_LOG_FILE:-}" ]]; then
+      log_info "  Cleaning etcd logs..."
+      for node in $META_NODES; do
+        ssh_exec_sudo "$node" "rm -f '${ETCD_LOG_FILE}' 2>/dev/null || true"
+      done
+    fi
+
+    log_success "Data cleanup complete"
+  fi
+
+  log_success "Cleanup complete"
+}
+
+case "$ACTION" in
+  prepare)
+    prepare
+    ;;
+  deploy-slayerfs)
+    prepare
+    deploy_slayerfs
+    ;;
+  test-slayerfs)
+    prepare
+    test_slayerfs
+    ;;
+  collect)
+    collect_results
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  all)
+    prepare
+    deploy_slayerfs
+    test_slayerfs
+    collect_results
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
#340 
- Created a new `.gitignore` file to exclude environment and results directories.
- Added `cluster.env.example` as an example configuration for distributed tests.
- Implemented `common.sh` for logging and utility functions.
- Developed `slayerfs.sh` for managing SlayerFS deployment and configuration.
- Created `ssh.sh` for SSH and SCP operations.
- Added `tests.sh` for running various performance tests on SlayerFS.
- Implemented `run-distributed-tests.sh` to orchestrate the testing process, including preparation, deployment, testing, result collection, and cleanup.