### PR TITLE
chore(dependencies): update qlean to version 0.1.1

### DIFF
--- a/project/Cargo.lock
+++ b/project/Cargo.lock
@@ -6299,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "qlean"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470f73af2bd5ec2ad1ea20d6ff1f0062fccfb8f0a75afa30deccad6b0da718d3"
+checksum = "29348473f9420b83082acbec4f5fb866e201c9c358ef1a5b5364e3fc0be510dc"
 dependencies = [
  "anyhow",
  "console",

--- a/project/Cargo.toml
+++ b/project/Cargo.toml
@@ -231,6 +231,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 pprof = { version = "0.15", features = ["criterion", "flamegraph"] }
 if-addrs = "0.6.0"
 redis = { version = "0.26", features = ["tokio-comp", "connection-manager"] }
+qlean = "0.1.1"
 
 [profile.release]
 debug = true

--- a/project/distribution/Cargo.toml
+++ b/project/distribution/Cargo.toml
@@ -35,4 +35,4 @@ reqwest = { workspace = true, features = ["json"] }
 rand = { workspace = true }
 
 [dev-dependencies]
-qlean = "0.1"
+qlean = { workspace = true }


### PR DESCRIPTION
- Updated qlean dependency version in Cargo.toml and distribution Cargo.toml.
- Adjusted checksum in Cargo.lock to reflect the new version.

This update ensures compatibility with the latest features and fixes in the qlean crate, and resolves the issue of verification failure when pulling remote images.