### PR TITLE
fix: fix set container readiness bug, network connection with rks bug, and pod list problem

### DIFF
--- a/project/common/src/lib.rs
+++ b/project/common/src/lib.rs
@@ -619,15 +619,6 @@ pub struct ContainerStatus {
 
     #[serde(default)]
     pub restart_count: u32,
-
-    #[serde(rename = "readinessProbe", default)]
-    pub readiness_probe: Option<ContainerProbeStatus>,
-
-    #[serde(rename = "livenessProbe", default)]
-    pub liveness_probe: Option<ContainerProbeStatus>,
-
-    #[serde(rename = "startupProbe", default)]
-    pub startup_probe: Option<ContainerProbeStatus>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/project/rkl/src/commands/pod/cluster.rs
+++ b/project/rkl/src/commands/pod/cluster.rs
@@ -96,6 +96,7 @@ fn list_print(pod_list: Vec<PodTask>) -> Result<()> {
         let age = pod
             .metadata
             .creation_timestamp
+            .or(pod.status.start_time)
             .map(|ts| {
                 let duration = Utc::now().signed_duration_since(ts);
                 format_duration(duration)

--- a/project/rks/src/commands/create.rs
+++ b/project/rks/src/commands/create.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 use crate::api::xlinestore::XlineStore;
 use anyhow::Result;
+use chrono::Utc;
 use clap::builder::Str;
 use common::quic::SendStreamExt;
 use common::{PodTask, RksMessage};
@@ -46,6 +47,9 @@ pub async fn user_create(
         }
         return Ok(());
     }
+
+    let mut pod_task = pod_task;
+    pod_task.metadata.creation_timestamp = Some(Utc::now());
 
     // Serialize pod to YAML
     let pod_yaml = match serde_yaml::to_string(&pod_task) {


### PR DESCRIPTION
## 修复几个和状态监测有关的bug
1. container readiness初始状态无法被正确设置，导致PodCondition中的PodReady永远为false
2. pod创建时间没有赋值导致pod list命令输出的AGE总是unknown
3. 与rks通信有误导致无法将本地的pod状态正确上报给rks