### PR TITLE
fix(distribution): make compose deployment work with workspace build …

### DIFF
--- a/project/distribution/Dockerfile
+++ b/project/distribution/Dockerfile
@@ -1,31 +1,19 @@
-FROM rust:1-slim as builder
+FROM rust:1-slim AS builder
 
 ARG PROFILE=debug
 
-WORKDIR /usr/src/app
+WORKDIR /app
 
-# Install necessary packages for building Rust applications with OpenSSL
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo init --bin .
-COPY Cargo.toml ./
-
+COPY . .
 RUN if [ "$PROFILE" = "release" ]; then \
-        cargo build --release; \
+        cargo build -p distribution --release; \
     else \
-        cargo build; \
-    fi
-
-COPY src ./src
-COPY migrations ./migrations
-RUN touch src/main.rs && \
-    if [ "$PROFILE" = "release" ]; then \
-        cargo build --release; \
-    else \
-        cargo build; \
+        cargo build -p distribution; \
     fi
 
 FROM debian:stable-slim
@@ -42,7 +30,7 @@ ARG GID=1001
 RUN groupadd -g $GID $APP_GROUP && \
     useradd -u $UID -g $APP_GROUP -s /bin/sh -m $APP_USER
 
-COPY --from=builder /usr/src/app/target/ /tmp/target/
+COPY --from=builder /app/target/ /tmp/target/
 RUN if [ "$PROFILE" = "release" ]; then \
         cp /tmp/target/release/distribution /usr/local/bin/distribution; \
     else \

--- a/project/distribution/compose.yaml
+++ b/project/distribution/compose.yaml
@@ -1,8 +1,12 @@
+# docker compose --env-file .env build distribution
+# docker compose --env-file .env up -d
+# docker compose logs -f distribution
+
 services:
   distribution:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: distribution/Dockerfile
       args:
         PROFILE: ${PROFILE:-debug}
         OCI_REGISTRY_PORT: ${OCI_REGISTRY_PORT}
@@ -15,7 +19,7 @@ services:
     environment:
       PROFILE: ${PROFILE}
 
-      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}"
 
       OCI_REGISTRY_URL: ${OCI_REGISTRY_URL}
       OCI_REGISTRY_PORT: ${OCI_REGISTRY_PORT}
@@ -30,7 +34,8 @@ services:
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
     image: postgres:15
@@ -39,6 +44,12 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
- build distribution from workspace root with cargo build -p distribution
- switch compose build context to project root and use distribution/Dockerfile
- use db:5432 in DATABASE_URL instead of localhost for container networking
- wait for postgres healthcheck before starting distribution