### PR TITLE
feat(rkforge): align build -t semantics with image refs and tag-aware…

### DIFF
--- a/project/rkforge/README.md
+++ b/project/rkforge/README.md
@@ -120,6 +120,23 @@ Alternatively, use `--libfuse` option to avoid sudo (uses userspace FUSE):
 
 Here the last optional `.` specifies the build context, which by default is `.`.
 
+#### `-t` and output directory behavior
+
+- `-t/--tag` is an image reference.
+- Accepted format: `[registry/]repository[:tag]`. You can repeat `-t` multiple times.
+- If no explicit tag is provided, rkforge treats it as `latest`.
+- Build output directory is derived from the first `-t` under `-o/--output-dir`:
+  - `-t image1` -> `output/image1`
+  - `-t nginx:latest` -> `output/nginx-latest`
+  - `-t example.com/ns/app:v1 -t example.com/ns/app:latest` -> `output/app-v1`
+
+Example:
+
+```sh
+sudo rkforge build -f Dockerfile -t nginx:latest -o output .
+# OCI layout output directory: output/nginx-latest
+```
+
 ### Example result
 
 The output is as follows:
@@ -299,7 +316,7 @@ rkforge pull nginx:latest
 rkforge pull library/nginx:latest
 
 # Similarly for push:
-rkforge push --path output/nginx nginx:latest  # Pushes to library/nginx:latest
+rkforge push --path output/nginx-latest nginx:latest  # Pushes to library/nginx:latest
 ```
 
 This behavior matches Docker Hub, where official images are stored under the `library/` namespace. To use this feature, create a user named `library` on your distribution server and configure rkforge with that user's credentials.
@@ -424,11 +441,14 @@ Options:
 ### Build Command
 
 ```sh
-Usage: rkforge build [OPTIONS]
+Usage: rkforge build [OPTIONS] [CONTEXT]
+
+Arguments:
+  [CONTEXT]  Build context. Defaults to the directory of the Dockerfile [default: .]
 
 Options:
   -f, --file <FILE>       Dockerfile or Containerfile
-  -t, --tag <IMAGE NAME>  Name of the resulting image
+  -t, --tag <NAME>        Image identifier (format: "[registry/]repository[:tag]"), can be set multiple times
   -v, --verbose           Turn verbose logging on
   -l, --libfuse           Use libfuse-rs or linux mount
   -o, --output-dir <DIR>  Output directory for the image

--- a/project/rkforge/src/image/executor.rs
+++ b/project/rkforge/src/image/executor.rs
@@ -30,6 +30,7 @@ pub struct Executor {
     pub image_config: ImageConfig,
     pub image_aliases: HashMap<String, String>,
     pub image_layers: Vec<LayerCompressionResult>,
+    pub image_ref_names: Vec<String>,
     pub global_args: HashMap<String, Option<String>>,
 
     pub compressor: Arc<dyn LayerCompressor + Send + Sync>,
@@ -40,6 +41,7 @@ impl Executor {
         dockerfile: Dockerfile,
         context: PathBuf,
         image_output_dir: PathBuf,
+        image_ref_names: Vec<String>,
         global_args: HashMap<String, Option<String>>,
         compressor: Arc<dyn LayerCompressor + Send + Sync>,
     ) -> Self {
@@ -53,6 +55,7 @@ impl Executor {
             image_config: ImageConfig::default(),
             image_aliases: HashMap::new(),
             image_layers: Vec::new(),
+            image_ref_names,
             global_args,
             compressor,
         }
@@ -139,7 +142,7 @@ impl Executor {
                 .collect::<Vec<(u64, String)>>(),
         )?;
 
-        let image_index = OciImageIndex::default();
+        let image_index = OciImageIndex::default().reference_names(self.image_ref_names.clone());
         let oci_builder = OciBuilder::default()
             .image_dir(self.image_output_dir.clone())
             .oci_image_config(image_config)

--- a/project/rkforge/src/image/mod.rs
+++ b/project/rkforge/src/image/mod.rs
@@ -4,16 +4,17 @@ pub mod execute;
 pub mod executor;
 pub mod stage_executor;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::compressor::tar_gz_compressor::TarGzCompressor;
 use crate::image::executor::Executor;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use dockerfile_parser::Dockerfile;
+use oci_spec::distribution::Reference;
 use rand::{Rng, distr::Alphanumeric};
 
 pub static BLOBS: &str = "blobs/sha256";
@@ -24,9 +25,9 @@ pub struct BuildArgs {
     #[arg(short, long, value_name = "FILE")]
     pub file: Option<PathBuf>,
 
-    /// Name of the resulting image
-    #[arg(short, long, value_name = "IMAGE NAME")]
-    pub tag: Option<String>,
+    /// Image identifier (format: "[registry/]repository[:tag]"), can be set multiple times
+    #[arg(short = 't', long = "tag", value_name = "NAME")]
+    pub tags: Vec<String>,
 
     /// Turn verbose logging on
     #[arg(short, long)]
@@ -66,6 +67,106 @@ fn parse_global_args(dockerfile: &Dockerfile) -> HashMap<String, Option<String>>
         .collect()
 }
 
+#[derive(Debug, Clone)]
+struct ParsedTag {
+    repository: String,
+    ref_name: String,
+    has_explicit_tag: bool,
+}
+
+fn has_explicit_tag(raw: &str) -> bool {
+    let last_colon = raw.rfind(':');
+    let last_slash = raw.rfind('/');
+    match (last_colon, last_slash) {
+        (Some(colon), Some(slash)) => colon > slash,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+fn parse_tag(raw: &str) -> Result<ParsedTag> {
+    if raw.trim().is_empty() {
+        bail!("invalid -t/--tag: empty value");
+    }
+    if raw.contains('@') {
+        bail!("invalid -t/--tag `{raw}`: digest references are not supported");
+    }
+
+    let reference = raw
+        .parse::<Reference>()
+        .with_context(|| format!("invalid -t/--tag image reference: `{raw}`"))?;
+
+    let repository = reference.repository().to_string();
+    let has_explicit_tag = has_explicit_tag(raw);
+    let explicit_tag = reference.tag().map(|v| v.to_string());
+    let ref_name = explicit_tag.clone().unwrap_or_else(|| "latest".to_string());
+
+    Ok(ParsedTag {
+        repository,
+        ref_name,
+        has_explicit_tag,
+    })
+}
+
+fn parse_tags(tags: &[String]) -> Result<Vec<ParsedTag>> {
+    tags.iter().map(|tag| parse_tag(tag)).collect()
+}
+
+fn normalize_output_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    let mut prev_dash = false;
+
+    for ch in name.chars() {
+        let is_valid = ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_');
+        let mapped = if is_valid { ch } else { '-' };
+        if mapped == '-' {
+            if prev_dash {
+                continue;
+            }
+            prev_dash = true;
+        } else {
+            prev_dash = false;
+        }
+        normalized.push(mapped);
+    }
+
+    let normalized = normalized.trim_matches('-').to_string();
+    if normalized.is_empty() {
+        "image".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn derive_output_name(parsed_tags: &[ParsedTag], rng: impl FnOnce() -> String) -> String {
+    if let Some(primary) = parsed_tags.first() {
+        let repo_basename = primary
+            .repository
+            .rsplit('/')
+            .next()
+            .unwrap_or(primary.repository.as_str());
+        let seed = if primary.has_explicit_tag {
+            format!("{repo_basename}-{}", primary.ref_name)
+        } else {
+            repo_basename.to_string()
+        };
+        return normalize_output_name(&seed);
+    }
+
+    normalize_output_name(&rng())
+}
+
+fn unique_ref_names(parsed_tags: &[ParsedTag]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut uniq = Vec::new();
+    for tag in parsed_tags {
+        if seen.insert(tag.ref_name.clone()) {
+            uniq.push(tag.ref_name.clone());
+        }
+    }
+    uniq
+}
+
 pub fn build_image(build_args: &BuildArgs) -> Result<()> {
     if let Some(dockerfile_path) = build_args.file.as_ref() {
         let dockerfile = parse_dockerfile(dockerfile_path)?;
@@ -78,15 +179,20 @@ pub fn build_image(build_args: &BuildArgs) -> Result<()> {
 
         let context = build_args.context.clone();
 
-        let tag = build_args.tag.clone().unwrap_or_else(|| {
+        let parsed_tags = parse_tags(&build_args.tags)?;
+        let output_name = derive_output_name(&parsed_tags, || {
             let rng = rand::rng();
             rng.sample_iter(&Alphanumeric)
                 .take(10)
                 .map(char::from)
                 .collect::<String>()
         });
-
-        let image_output_dir = PathBuf::from(format!("{output_dir}/{tag}"));
+        let image_output_dir = PathBuf::from(format!("{output_dir}/{output_name}"));
+        let ref_names = if parsed_tags.is_empty() {
+            vec!["latest".to_string()]
+        } else {
+            unique_ref_names(&parsed_tags)
+        };
 
         if image_output_dir.exists() {
             fs::remove_dir_all(&image_output_dir)?;
@@ -99,6 +205,7 @@ pub fn build_image(build_args: &BuildArgs) -> Result<()> {
             dockerfile,
             context,
             image_output_dir,
+            ref_names,
             global_args,
             Arc::new(TarGzCompressor),
         );
@@ -114,12 +221,12 @@ pub fn build_image(build_args: &BuildArgs) -> Result<()> {
 mod tests {
     use std::path::PathBuf;
 
+    use super::{
+        BuildArgs, derive_output_name, has_explicit_tag, parse_dockerfile, parse_tags,
+        unique_ref_names,
+    };
     use clap::Parser;
     use dockerfile_parser::{BreakableStringComponent, Instruction, ShellOrExecExpr};
-    use rand::{Rng, distr::Alphanumeric};
-
-    use super::BuildArgs;
-    use super::parse_dockerfile;
 
     #[test]
     fn test_dockerfile() {
@@ -127,6 +234,7 @@ mod tests {
             BuildArgs::parse_from(vec!["rkforge", "-f", "example-Dockerfile", "-t", "image1"]);
 
         assert_eq!(build_args.file, Some(PathBuf::from("example-Dockerfile")));
+        assert_eq!(build_args.tags, vec!["image1".to_string()]);
         let dockerfile = parse_dockerfile(PathBuf::from("example-Dockerfile")).unwrap();
         assert_eq!(dockerfile.instructions.len(), 4);
     }
@@ -138,49 +246,86 @@ mod tests {
             "-f",
             "example-Dockerfile",
             "-t",
-            "image1",
+            "repo/image1:latest",
             "-o",
             "output_dir",
         ]);
 
-        let output_dir = build_args
-            .output_dir
-            .as_ref()
-            .map(|dir| dir.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| ".".to_string());
-
-        let tag = build_args.tag.clone().unwrap_or_else(|| {
-            let rng = rand::rng();
-            rng.sample_iter(&Alphanumeric)
-                .take(10)
-                .map(char::from)
-                .collect::<String>()
-        });
-
-        let image_output_dir = PathBuf::from(&format!("{output_dir}/{tag}"));
-
-        assert_eq!("output_dir/image1", image_output_dir.to_str().unwrap());
+        let parsed_tags = parse_tags(&build_args.tags).unwrap();
+        let output_name = derive_output_name(&parsed_tags, || "RANDOM".to_string());
+        assert_eq!("image1-latest", output_name);
 
         let build_args = BuildArgs::parse_from(vec!["rkforge", "-f", "example-Dockerfile"]);
 
-        let output_dir = build_args
-            .output_dir
-            .as_ref()
-            .map(|dir| dir.trim_end_matches('/').to_string())
-            .unwrap_or_else(|| ".".to_string());
+        let parsed_tags = parse_tags(&build_args.tags).unwrap();
+        let output_name = derive_output_name(&parsed_tags, || "RANDOM".to_string());
 
-        let tag = build_args.tag.clone().unwrap_or_else(|| {
-            let rng = rand::rng();
-            rng.sample_iter(&Alphanumeric)
-                .take(10)
-                .map(char::from)
-                .collect::<String>()
-        });
+        assert_eq!("RANDOM", output_name);
+    }
 
-        let image_output_dir = PathBuf::from(&format!("{output_dir}/{tag}"));
+    #[test]
+    fn test_parse_multiple_tags() {
+        let build_args = BuildArgs::parse_from(vec![
+            "rkforge",
+            "-f",
+            "example-Dockerfile",
+            "-t",
+            "example.com/ns/app:v1",
+            "-t",
+            "ns/app:v2",
+        ]);
+        assert_eq!(
+            build_args.tags,
+            vec!["example.com/ns/app:v1".to_string(), "ns/app:v2".to_string()]
+        );
+    }
 
-        assert!(image_output_dir.to_str().unwrap().starts_with("./"));
-        assert_eq!(image_output_dir.to_str().unwrap().len(), 12);
+    #[test]
+    fn test_parse_tag_variants() {
+        let parsed = parse_tags(&[
+            "nginx".to_string(),
+            "nginx:v1".to_string(),
+            "registry.io/ns/app:latest".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(parsed[0].ref_name, "latest");
+        assert!(!parsed[0].has_explicit_tag);
+        assert_eq!(parsed[0].repository, "library/nginx");
+
+        assert_eq!(parsed[1].ref_name, "v1");
+        assert!(parsed[1].has_explicit_tag);
+
+        assert_eq!(parsed[2].repository, "ns/app");
+        assert_eq!(parsed[2].ref_name, "latest");
+    }
+
+    #[test]
+    fn test_parse_tag_invalid() {
+        assert!(parse_tags(&["".to_string()]).is_err());
+        assert!(parse_tags(&["nginx@sha256:abc123".to_string()]).is_err());
+    }
+
+    #[test]
+    fn test_has_explicit_tag() {
+        assert!(!has_explicit_tag("nginx"));
+        assert!(!has_explicit_tag("localhost:5000/ns/app"));
+        assert!(has_explicit_tag("nginx:v1"));
+        assert!(has_explicit_tag("localhost:5000/ns/app:v1"));
+    }
+
+    #[test]
+    fn test_unique_ref_names() {
+        let parsed = parse_tags(&[
+            "repo/a:latest".to_string(),
+            "repo/b:latest".to_string(),
+            "repo/c:v1".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(
+            unique_ref_names(&parsed),
+            vec!["latest".to_string(), "v1".to_string()]
+        );
     }
 
     #[test]

--- a/project/rkforge/src/oci_spec/index.rs
+++ b/project/rkforge/src/oci_spec/index.rs
@@ -6,31 +6,48 @@ use std::{collections::HashMap, str::FromStr};
 
 pub struct OciImageIndex {
     pub image_index_builder: ImageIndexBuilder,
+    pub reference_names: Vec<String>,
 }
 
 impl OciImageIndex {
+    pub fn reference_names(mut self, reference_names: Vec<String>) -> Self {
+        self.reference_names = if reference_names.is_empty() {
+            vec!["latest".to_string()]
+        } else {
+            reference_names
+        };
+        self
+    }
+
     pub fn manifests(mut self, manifests: Vec<(u64, String)>) -> Result<Self> {
         let mut descriptors = Vec::new();
+        let reference_names = if self.reference_names.is_empty() {
+            vec!["latest".to_string()]
+        } else {
+            self.reference_names.clone()
+        };
 
         for (size, digest_str) in manifests.iter() {
-            let descriptor = DescriptorBuilder::default()
-                .media_type(MediaType::ImageManifest)
-                .size(*size)
-                .digest(
-                    Sha256Digest::from_str(digest_str.as_str())
-                        .with_context(|| format!("Invalid digest format: {digest_str}"))?,
-                )
-                .annotations(
-                    vec![(
-                        String::from("org.opencontainers.image.ref.name"),
-                        String::from("latest"),
-                    )]
-                    .into_iter()
-                    .collect::<HashMap<_, _>>(),
-                )
-                .build()?;
+            for ref_name in &reference_names {
+                let descriptor = DescriptorBuilder::default()
+                    .media_type(MediaType::ImageManifest)
+                    .size(*size)
+                    .digest(
+                        Sha256Digest::from_str(digest_str.as_str())
+                            .with_context(|| format!("Invalid digest format: {digest_str}"))?,
+                    )
+                    .annotations(
+                        vec![(
+                            String::from("org.opencontainers.image.ref.name"),
+                            ref_name.to_string(),
+                        )]
+                        .into_iter()
+                        .collect::<HashMap<_, _>>(),
+                    )
+                    .build()?;
 
-            descriptors.push(descriptor);
+                descriptors.push(descriptor);
+            }
         }
 
         self.image_index_builder = self.image_index_builder.manifests(descriptors);
@@ -50,6 +67,39 @@ impl Default for OciImageIndex {
             .media_type(MediaType::ImageIndex);
         OciImageIndex {
             image_index_builder,
+            reference_names: vec!["latest".to_string()],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OciImageIndex;
+
+    #[test]
+    fn test_multiple_reference_names() {
+        let digest = "a".repeat(64);
+        let image_index = OciImageIndex::default()
+            .reference_names(vec!["v1".to_string(), "latest".to_string()])
+            .manifests(vec![(123, digest)])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(image_index.manifests().len(), 2);
+        let mut refs = image_index
+            .manifests()
+            .iter()
+            .map(|descriptor| {
+                descriptor
+                    .annotations()
+                    .as_ref()
+                    .and_then(|ann| ann.get("org.opencontainers.image.ref.name"))
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<_>>();
+        refs.sort();
+        assert_eq!(refs, vec!["latest".to_string(), "v1".to_string()]);
     }
 }

--- a/project/rkforge/src/push/mod.rs
+++ b/project/rkforge/src/push/mod.rs
@@ -4,13 +4,14 @@ use crate::config::auth::AuthConfig;
 use crate::push::pusher::{PushTask, Pusher};
 use crate::rt::block_on;
 use crate::storage::{DigestExt, parse_image_ref};
-use anyhow::Context;
+use anyhow::{Context, bail};
 use clap::Parser;
 use oci_client::client::{ClientConfig, ImageLayer};
 use oci_client::manifest::{OciImageIndex, OciManifest};
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, client};
 use oci_spec::distribution::Reference;
+use std::collections::HashMap;
 use std::path::Path;
 use tokio::io::AsyncReadExt;
 
@@ -41,6 +42,15 @@ pub struct PushArgs {
 
 pub fn push(args: PushArgs) -> anyhow::Result<()> {
     let auth_config = AuthConfig::load()?;
+    let requested_has_explicit_tag = has_explicit_tag(&args.image_ref);
+
+    let requested_ref = args.image_ref.parse::<Reference>().with_context(|| {
+        format!(
+            "invalid image reference for push: {}",
+            args.image_ref.as_str()
+        )
+    })?;
+    let requested_repo = requested_ref.repository().to_string();
 
     let url = auth_config.resolve_url(args.url);
 
@@ -57,8 +67,20 @@ pub fn push(args: PushArgs) -> anyhow::Result<()> {
 
     let image_ref = parse_image_ref(url, args.image_ref, None::<String>)?;
     let path = args.path.unwrap_or(".".to_string());
+    let registry_url = image_ref.registry().to_string();
 
-    block_on(async move { push_image(&client, &image_ref, &auth_method, path).await })?
+    block_on(async move {
+        push_image(
+            &client,
+            &image_ref,
+            &auth_method,
+            path,
+            &registry_url,
+            &requested_repo,
+            requested_has_explicit_tag,
+        )
+        .await
+    })?
 }
 
 pub async fn push_image(
@@ -66,8 +88,13 @@ pub async fn push_image(
     image_ref: &Reference,
     auth_method: &RegistryAuth,
     path: impl AsRef<Path>,
+    registry_url: impl AsRef<str>,
+    requested_repo: impl AsRef<str>,
+    requested_has_explicit_tag: bool,
 ) -> anyhow::Result<()> {
     let dir = path.as_ref();
+    let registry_url = registry_url.as_ref();
+    let requested_repo = requested_repo.as_ref();
 
     let image_index_path = dir.join("index.json");
     let image_index = serde_json::from_str::<OciImageIndex>(
@@ -77,12 +104,39 @@ pub async fn push_image(
     )?;
 
     let dir = dir.join("blobs/sha256");
+    let requested_tag = if requested_has_explicit_tag {
+        image_ref.tag().map(|tag| tag.to_string())
+    } else {
+        None
+    };
+
+    let mut digest_to_ref_names: HashMap<String, Vec<String>> = HashMap::new();
+    for descriptor in &image_index.manifests {
+        let digest = descriptor.digest.split_digest()?.to_string();
+        let ref_name = descriptor
+            .annotations
+            .as_ref()
+            .and_then(|ann| ann.get("org.opencontainers.image.ref.name"))
+            .cloned()
+            .unwrap_or_else(|| "latest".to_string());
+
+        let entry = digest_to_ref_names.entry(digest).or_default();
+        if !entry.contains(&ref_name) {
+            entry.push(ref_name);
+        }
+    }
 
     let mut tasks = Vec::new();
-    for entry in image_index.manifests {
-        let digest = entry.digest.split_digest()?;
+    let mut matched_requested_tag = false;
+    for (digest, ref_names) in digest_to_ref_names {
+        if !should_include_digest(requested_tag.as_deref(), &ref_names) {
+            continue;
+        }
+        if requested_tag.is_some() {
+            matched_requested_tag = true;
+        }
 
-        let manifest_path = dir.join(digest);
+        let manifest_path = dir.join(&digest);
         let manifest = serde_json::from_str::<OciManifest>(
             &tokio::fs::read_to_string(&manifest_path)
                 .await
@@ -93,33 +147,96 @@ pub async fn push_image(
             OciManifest::ImageIndex(_) => anyhow::bail!("Image indexes are not supported yet"),
         };
 
-        let descriptors = &manifest.layers;
-        let mut layers = Vec::new();
+        let target_refs = if requested_tag.is_some() {
+            vec![image_ref.clone()]
+        } else {
+            ref_names
+                .into_iter()
+                .map(|ref_name| {
+                    parse_image_ref(registry_url, requested_repo, Some(ref_name.as_str()))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+        };
 
-        for descriptor in descriptors {
-            let layer_path = dir.join(descriptor.digest.split_digest()?);
-            let layer = from_oci_blob!(ImageLayer, layer_path, descriptor);
-            layers.push(layer);
+        for target_ref in target_refs {
+            let descriptors = &manifest.layers;
+            let mut layers = Vec::new();
+
+            for descriptor in descriptors {
+                let layer_path = dir.join(descriptor.digest.split_digest()?);
+                let layer = from_oci_blob!(ImageLayer, layer_path, descriptor);
+                layers.push(layer);
+            }
+
+            let config_path = dir.join(manifest.config.digest.split_digest()?);
+            let config = from_oci_blob!(client::Config, config_path, manifest.config);
+
+            let auth_method = auth_method.clone();
+            let client = client.clone();
+            let digest_with_ref = format!("{digest}@{}", target_ref.whole());
+            let manifest = manifest.clone();
+            let task = PushTask::new(
+                digest_with_ref,
+                Box::pin(async move {
+                    client
+                        .push(&target_ref, &layers, config, &auth_method, Some(manifest))
+                        .await
+                }),
+            );
+            tasks.push(task);
         }
+    }
 
-        let config_path = dir.join(manifest.config.digest.split_digest()?);
-        let config = from_oci_blob!(client::Config, config_path, manifest.config);
-
-        let image_ref = image_ref.clone();
-        let auth_method = auth_method.clone();
-        let client = client.clone();
-        let task = PushTask::new(
-            digest,
-            Box::pin(async move {
-                client
-                    .push(&image_ref, &layers, config, &auth_method, Some(manifest))
-                    .await
-            }),
-        );
-        tasks.push(task);
+    if let Some(tag) = requested_tag
+        && !matched_requested_tag
+    {
+        bail!("tag `{tag}` not found in index.json");
     }
 
     let pusher = Pusher::new(tasks);
     pusher.push_all().await?;
     Ok(())
+}
+
+fn should_include_digest(requested_tag: Option<&str>, ref_names: &[String]) -> bool {
+    match requested_tag {
+        Some(tag) => ref_names.iter().any(|ref_name| ref_name == tag),
+        None => true,
+    }
+}
+
+fn has_explicit_tag(raw: &str) -> bool {
+    let last_colon = raw.rfind(':');
+    let last_slash = raw.rfind('/');
+    match (last_colon, last_slash) {
+        (Some(colon), Some(slash)) => colon > slash,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_explicit_tag, should_include_digest};
+
+    #[test]
+    fn test_should_include_digest_for_explicit_tag() {
+        let refs = vec!["latest".to_string(), "v1".to_string()];
+        assert!(should_include_digest(Some("v1"), &refs));
+        assert!(!should_include_digest(Some("v2"), &refs));
+    }
+
+    #[test]
+    fn test_should_include_digest_without_explicit_tag() {
+        let refs = vec!["latest".to_string()];
+        assert!(should_include_digest(None, &refs));
+    }
+
+    #[test]
+    fn test_has_explicit_tag() {
+        assert!(!has_explicit_tag("repo/app"));
+        assert!(!has_explicit_tag("localhost:5000/repo/app"));
+        assert!(has_explicit_tag("repo/app:v1"));
+        assert!(has_explicit_tag("localhost:5000/repo/app:v1"));
+    }
 }


### PR DESCRIPTION
- change build -t/--tag to parse OCI image references and support multiple tags
- derive output OCI layout directory from the first tag safely (instead of raw tag path)
- propagate tag ref names through executor and write them into OCI index annotations
- support multiple ref names in index manifests (instead of hardcoded latest)
- make push tag-aware by digest/ref mapping:
  - explicit tag: push only matching manifest(s), error if tag not found in index
  - implicit tag: keep existing multi-ref expansion behavior
- add/adjust tests for tag parsing, explicit-tag detection, ref dedup, and push filtering