### PR TITLE
feat(rkforge/build): add --secret and --ssh support for RUN

### DIFF
--- a/project/rkforge/src/image/build_runtime.rs
+++ b/project/rkforge/src/image/build_runtime.rs
@@ -5,6 +5,18 @@ use std::net::IpAddr;
 use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BuildSecret {
+    pub id: String,
+    pub src: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BuildSshAgent {
+    pub id: String,
+    pub socket_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuildHostEntry {
     pub host: String,
     pub ip: IpAddr,

--- a/project/rkforge/src/image/context.rs
+++ b/project/rkforge/src/image/context.rs
@@ -3,7 +3,9 @@ use std::{collections::HashMap, path::Path};
 use crate::{
     image::{
         BuildProgressMode,
-        build_runtime::{BuildHostEntry, BuildNetworkMode, BuildUlimit},
+        build_runtime::{
+            BuildHostEntry, BuildNetworkMode, BuildSecret, BuildSshAgent, BuildUlimit,
+        },
         config::ImageConfig,
     },
     overlayfs::MountConfig,
@@ -32,4 +34,6 @@ pub struct StageContext<'ctx, P: AsRef<Path>> {
     pub ulimits: &'ctx [BuildUlimit],
     pub network_mode: BuildNetworkMode,
     pub cgroup_parent: Option<String>,
+    pub secrets: &'ctx [BuildSecret],
+    pub ssh: &'ctx [BuildSshAgent],
 }

--- a/project/rkforge/src/image/execute.rs
+++ b/project/rkforge/src/image/execute.rs
@@ -349,6 +349,12 @@ impl<P: AsRef<Path>> InstructionExt<P> for RunInstruction {
                 merged_envp.insert(key.clone(), value.clone());
             }
         }
+        if !ctx.ssh.is_empty() && !merged_envp.contains_key("SSH_AUTH_SOCK") {
+            merged_envp.insert(
+                "SSH_AUTH_SOCK".to_string(),
+                "/run/rkforge/ssh/ssh_agent.0".to_string(),
+            );
+        }
         let envp: Vec<String> = merged_envp
             .iter()
             .map(|(k, v)| format!("{k}={v}"))
@@ -365,6 +371,8 @@ impl<P: AsRef<Path>> InstructionExt<P> for RunInstruction {
             ulimits: ctx.ulimits.to_vec(),
             network_mode: ctx.network_mode,
             cgroup_parent: ctx.cgroup_parent.clone(),
+            secrets: ctx.secrets.to_vec(),
+            ssh: ctx.ssh.to_vec(),
         };
         task.execute(ctx.mount_config)
     }
@@ -519,6 +527,7 @@ mod tests {
     use crate::{
         image::{
             BuildProgressMode,
+            build_runtime::BuildNetworkMode,
             config::{DEFAULT_ENV, ImageConfig},
             context::StageContext,
         },
@@ -584,8 +593,10 @@ ARG BASE=alpine
             add_hosts: &[],
             shm_size: None,
             ulimits: &[],
-            network_mode: crate::image::build_runtime::BuildNetworkMode::Default,
+            network_mode: BuildNetworkMode::Default,
             cgroup_parent: None,
+            secrets: &[],
+            ssh: &[],
         };
 
         arg_inst.execute(&mut ctx).unwrap();
@@ -630,8 +641,10 @@ ARG BASE=alpine
             add_hosts: &[],
             shm_size: None,
             ulimits: &[],
-            network_mode: crate::image::build_runtime::BuildNetworkMode::Default,
+            network_mode: BuildNetworkMode::Default,
             cgroup_parent: None,
+            secrets: &[],
+            ssh: &[],
         };
 
         arg_inst.execute(&mut ctx).unwrap();
@@ -672,8 +685,10 @@ ENV A=1 B=$A
             add_hosts: &[],
             shm_size: None,
             ulimits: &[],
-            network_mode: crate::image::build_runtime::BuildNetworkMode::Default,
+            network_mode: BuildNetworkMode::Default,
             cgroup_parent: None,
+            secrets: &[],
+            ssh: &[],
         };
 
         dockerfile

--- a/project/rkforge/src/image/executor.rs
+++ b/project/rkforge/src/image/executor.rs
@@ -2,7 +2,9 @@ use crate::{
     compressor::{LayerCompressionConfig, LayerCompressionResult, LayerCompressor},
     image::{
         BLOBS, BuildProgressMode,
-        build_runtime::{BuildHostEntry, BuildNetworkMode, BuildUlimit},
+        build_runtime::{
+            BuildHostEntry, BuildNetworkMode, BuildSecret, BuildSshAgent, BuildUlimit,
+        },
         config::ImageConfig,
         context::StageContext,
         stage_executor::StageExecutor,
@@ -52,6 +54,8 @@ pub struct Executor {
     pub network_mode: BuildNetworkMode,
     pub cgroup_parent: Option<String>,
     pub no_cache_filters: Vec<String>,
+    pub secrets: Vec<BuildSecret>,
+    pub ssh: Vec<BuildSshAgent>,
 
     pub compressor: Arc<dyn LayerCompressor + Send + Sync>,
 }
@@ -104,6 +108,8 @@ impl Executor {
             network_mode: BuildNetworkMode::Default,
             cgroup_parent: None,
             no_cache_filters: Vec::new(),
+            secrets: Vec::new(),
+            ssh: Vec::new(),
             compressor,
         }
     }
@@ -150,6 +156,14 @@ impl Executor {
 
     pub fn no_cache_filter(&mut self, filters: Vec<String>) {
         self.no_cache_filters = filters;
+    }
+
+    pub fn secrets(&mut self, secrets: Vec<BuildSecret>) {
+        self.secrets = secrets;
+    }
+
+    pub fn ssh(&mut self, ssh: Vec<BuildSshAgent>) {
+        self.ssh = ssh;
     }
 
     pub fn build_image(&mut self) -> Result<()> {
@@ -294,6 +308,8 @@ impl Executor {
                     ulimits: &self.ulimits,
                     network_mode: self.network_mode,
                     cgroup_parent: self.cgroup_parent.clone(),
+                    secrets: &self.secrets,
+                    ssh: &self.ssh,
                 };
                 let mut stage_executor = StageExecutor::new(ctx, stage);
                 stage_executor.execute()

--- a/project/rkforge/src/image/mod.rs
+++ b/project/rkforge/src/image/mod.rs
@@ -16,8 +16,8 @@ use std::time::Instant;
 
 use crate::compressor::tar_gz_compressor::TarGzCompressor;
 use crate::image::build_runtime::{
-    BuildHostEntry, BuildNetworkMode, BuildUlimit, BuildUlimitResource, BuildUlimitValue,
-    normalize_cgroup_parent,
+    BuildHostEntry, BuildNetworkMode, BuildSecret, BuildSshAgent, BuildUlimit, BuildUlimitResource,
+    BuildUlimitValue, normalize_cgroup_parent,
 };
 use crate::image::executor::Executor;
 use crate::image::metadata::{BuildMetadata, write_metadata_file};
@@ -123,6 +123,14 @@ pub struct BuildArgs {
     /// Disable cache for specific stages by stage name or index (e.g. --no-cache-filter builder --no-cache-filter 0), can be set multiple times
     #[arg(long = "no-cache-filter", value_name = "STAGE")]
     pub no_cache_filter: Vec<String>,
+
+    /// Secret to expose to the build (format: "id=mysecret[,src=/local/secret]"), can be set multiple times
+    #[arg(long = "secret", value_name = "id=...[,src=...]", value_parser = parse_secret_option)]
+    pub secrets: Vec<BuildSecret>,
+
+    /// SSH agent socket or keys to expose to the build (format: "default|<id>[=<socket>]"), can be set multiple times
+    #[arg(long = "ssh", value_name = "default|<id>[=<socket>]", value_parser = parse_ssh_option)]
+    pub ssh: Vec<BuildSshAgent>,
 
     /// Build context. Defaults to the directory of the Dockerfile.
     #[arg(default_value = ".")]
@@ -259,6 +267,123 @@ fn parse_ulimit_option(raw: &str) -> std::result::Result<BuildUlimit, String> {
         soft,
         hard,
     })
+}
+
+fn parse_secret_option(raw: &str) -> std::result::Result<BuildSecret, String> {
+    let mut id = None;
+    let mut src = None;
+
+    for part in raw.split(',') {
+        let (key, value) = part.split_once('=').ok_or_else(|| {
+            format!("invalid --secret value `{raw}`: expected comma-separated KEY=VALUE pairs")
+        })?;
+        match key.trim() {
+            "id" => {
+                let v = value.trim();
+                if v.is_empty() {
+                    return Err(format!(
+                        "invalid --secret value `{raw}`: id must not be empty"
+                    ));
+                }
+                id = Some(v.to_string());
+            }
+            "src" => {
+                let v = value.trim();
+                if v.is_empty() {
+                    return Err(format!(
+                        "invalid --secret value `{raw}`: src must not be empty"
+                    ));
+                }
+                src = Some(PathBuf::from(v));
+            }
+            other => {
+                return Err(format!(
+                    "invalid --secret value `{raw}`: unknown key `{other}`"
+                ));
+            }
+        }
+    }
+
+    let id = id.ok_or_else(|| format!("invalid --secret value `{raw}`: missing required `id`"))?;
+
+    if id.contains('/') || id.contains('\\') || id.contains("..") || id.contains('\0') {
+        return Err(format!(
+            "invalid --secret value `{raw}`: id `{id}` must not contain path separators or `..`"
+        ));
+    }
+
+    let src = src.unwrap_or_else(|| PathBuf::from(&id));
+
+    if !src.exists() {
+        return Err(format!(
+            "invalid --secret value `{raw}`: source file `{}` does not exist",
+            src.display()
+        ));
+    }
+    if !src.is_file() {
+        return Err(format!(
+            "invalid --secret value `{raw}`: source `{}` is not a regular file",
+            src.display()
+        ));
+    }
+
+    let src = src
+        .canonicalize()
+        .map_err(|e| format!("invalid --secret value `{raw}`: failed to resolve path: {e}"))?;
+
+    Ok(BuildSecret { id, src })
+}
+
+fn parse_ssh_option(raw: &str) -> std::result::Result<BuildSshAgent, String> {
+    let (id, socket_path) = if let Some((id, path)) = raw.split_once('=') {
+        let id = id.trim();
+        if id.is_empty() {
+            return Err(format!("invalid --ssh value `{raw}`: id must not be empty"));
+        }
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(format!(
+                "invalid --ssh value `{raw}`: socket path must not be empty"
+            ));
+        }
+        (id.to_string(), PathBuf::from(path))
+    } else {
+        let id = raw.trim();
+        if id.is_empty() {
+            return Err("invalid --ssh value: id must not be empty".to_string());
+        }
+        let socket_path = std::env::var("SSH_AUTH_SOCK")
+            .map(PathBuf::from)
+            .map_err(|_| {
+                format!(
+                    "invalid --ssh value `{raw}`: no socket path specified and SSH_AUTH_SOCK is not set"
+                )
+            })?;
+        (id.to_string(), socket_path)
+    };
+
+    if !socket_path.exists() {
+        return Err(format!(
+            "invalid --ssh value `{raw}`: socket `{}` does not exist",
+            socket_path.display()
+        ));
+    }
+
+    use std::os::unix::fs::FileTypeExt;
+    let meta = std::fs::symlink_metadata(&socket_path).map_err(|e| {
+        format!(
+            "invalid --ssh value `{raw}`: failed to inspect `{}`: {e}",
+            socket_path.display()
+        )
+    })?;
+    if !meta.file_type().is_socket() {
+        return Err(format!(
+            "invalid --ssh value `{raw}`: `{}` is not a unix socket",
+            socket_path.display()
+        ));
+    }
+
+    Ok(BuildSshAgent { id, socket_path })
 }
 
 fn parse_dockerfile<P: AsRef<Path>>(dockerfile_path: P) -> Result<Dockerfile> {
@@ -565,6 +690,8 @@ pub fn build_image(build_args: &BuildArgs) -> Result<()> {
         cgroup_parent,
     );
     executor.no_cache_filter(no_cache_filters);
+    executor.secrets(build_args.secrets.clone());
+    executor.ssh(build_args.ssh.clone());
 
     executor.build_image()?;
 
@@ -605,8 +732,9 @@ mod tests {
     use super::{
         BuildArgs, BuildProgressMode, derive_output_name, has_explicit_tag,
         normalize_cgroup_parent_option, normalize_push_reference, parse_add_host_option,
-        parse_dockerfile, parse_global_args, parse_key_value_options, parse_shm_size, parse_tags,
-        parse_ulimit_option, read_primary_image_digest, resolve_dockerfile_path, unique_ref_names,
+        parse_dockerfile, parse_global_args, parse_key_value_options, parse_secret_option,
+        parse_shm_size, parse_ssh_option, parse_tags, parse_ulimit_option,
+        read_primary_image_digest, resolve_dockerfile_path, unique_ref_names,
     };
     use clap::Parser;
     use dockerfile_parser::{BreakableStringComponent, Dockerfile, Instruction, ShellOrExecExpr};
@@ -1029,5 +1157,130 @@ FROM ${BASE}
             digest,
             "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
         );
+    }
+
+    #[test]
+    fn test_parse_secret_option_with_src() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let secret_file = temp_dir.path().join("my_secret");
+        fs::write(&secret_file, b"supersecret").unwrap();
+
+        let raw = format!("id=mysecret,src={}", secret_file.display());
+        let parsed = parse_secret_option(&raw).unwrap();
+        assert_eq!(parsed.id, "mysecret");
+        assert_eq!(parsed.src, secret_file.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_parse_secret_option_default_src() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let secret_file = temp_dir.path().join("dbpass");
+        fs::write(&secret_file, b"p@ss").unwrap();
+
+        let raw = format!("id=dbpass,src={}", secret_file.display());
+        let parsed = parse_secret_option(&raw).unwrap();
+        assert_eq!(parsed.id, "dbpass");
+        assert_eq!(parsed.src, secret_file.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_parse_secret_option_missing_id() {
+        assert!(parse_secret_option("src=/tmp/x").is_err());
+    }
+
+    #[test]
+    fn test_parse_secret_option_missing_file() {
+        assert!(parse_secret_option("id=mysecret,src=/nonexistent/path").is_err());
+    }
+
+    #[test]
+    fn test_parse_secret_option_unknown_key() {
+        assert!(parse_secret_option("id=mysecret,foo=bar").is_err());
+    }
+
+    fn create_unix_socket(path: &std::path::Path) {
+        use std::os::unix::net::UnixListener;
+        let _ = UnixListener::bind(path).unwrap();
+    }
+
+    #[test]
+    fn test_parse_ssh_option_with_socket() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sock = temp_dir.path().join("agent.sock");
+        create_unix_socket(&sock);
+
+        let raw = format!("default={}", sock.display());
+        let parsed = parse_ssh_option(&raw).unwrap();
+        assert_eq!(parsed.id, "default");
+        assert_eq!(parsed.socket_path, sock);
+    }
+
+    #[test]
+    fn test_parse_ssh_option_missing_socket() {
+        assert!(parse_ssh_option("default=/nonexistent/socket").is_err());
+    }
+
+    #[test]
+    fn test_parse_ssh_option_empty_id() {
+        assert!(parse_ssh_option("").is_err());
+        assert!(parse_ssh_option("=/tmp/x").is_err());
+    }
+
+    #[test]
+    fn test_parse_ssh_option_named_agent() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sock = temp_dir.path().join("github.sock");
+        create_unix_socket(&sock);
+
+        let raw = format!("github={}", sock.display());
+        let parsed = parse_ssh_option(&raw).unwrap();
+        assert_eq!(parsed.id, "github");
+        assert_eq!(parsed.socket_path, sock);
+    }
+
+    #[test]
+    fn test_parse_ssh_option_rejects_regular_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let not_a_socket = temp_dir.path().join("regular.txt");
+        fs::write(&not_a_socket, b"hello").unwrap();
+
+        let raw = format!("default={}", not_a_socket.display());
+        let err = parse_ssh_option(&raw).unwrap_err();
+        assert!(err.contains("not a unix socket"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_parse_secret_option_path_traversal() {
+        assert!(parse_secret_option("id=../etc/passwd,src=/etc/hostname").is_err());
+        assert!(parse_secret_option("id=foo/../../etc/shadow,src=/etc/hostname").is_err());
+        assert!(parse_secret_option("id=sub/file,src=/etc/hostname").is_err());
+    }
+
+    #[test]
+    fn test_parse_1_with_secret_and_ssh() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let secret_file = temp_dir.path().join("token");
+        fs::write(&secret_file, b"secret_token").unwrap();
+        let ssh_sock = temp_dir.path().join("agent.sock");
+        create_unix_socket(&ssh_sock);
+
+        let secret_arg = format!("id=mytoken,src={}", secret_file.display());
+        let ssh_arg = format!("default={}", ssh_sock.display());
+
+        let build_args = BuildArgs::parse_from(vec![
+            "rkforge",
+            "-f",
+            "example-Dockerfile",
+            "--secret",
+            &secret_arg,
+            "--ssh",
+            &ssh_arg,
+            ".",
+        ]);
+
+        assert_eq!(build_args.secrets.len(), 1);
+        assert_eq!(build_args.secrets[0].id, "mytoken");
+        assert_eq!(build_args.ssh.len(), 1);
+        assert_eq!(build_args.ssh[0].id, "default");
     }
 }

--- a/project/rkforge/src/overlayfs/mod.rs
+++ b/project/rkforge/src/overlayfs/mod.rs
@@ -3,7 +3,7 @@ pub mod linux;
 
 use crate::config::image::CONFIG;
 use crate::image::build_runtime::{
-    BuildHostEntry, BuildUlimit, BuildUlimitResource, BuildUlimitValue,
+    BuildHostEntry, BuildSecret, BuildSshAgent, BuildUlimit, BuildUlimitResource, BuildUlimitValue,
 };
 use anyhow::{Context, Result, bail};
 use base64::{Engine, engine::general_purpose};
@@ -19,6 +19,8 @@ use std::path::{Component, Path, PathBuf};
 pub static DNS_CONFIG: &str = "/etc/resolv.conf";
 pub static HOSTS_CONFIG: &str = "/etc/hosts";
 pub static SHM_CONFIG: &str = "/dev/shm";
+pub static SECRETS_DIR: &str = "/run/secrets";
+pub static RKFORGE_SSH_DIR: &str = "/run/rkforge/ssh";
 pub static BIND_MOUNTS: [&str; 3] = ["/dev", "/proc", "/sys"];
 
 #[derive(Parser, Debug)]
@@ -785,38 +787,132 @@ pub fn prepare_shm<P: AsRef<Path>>(mountpoint: P, shm_size: Option<u64>) -> Resu
     Ok(())
 }
 
+pub fn prepare_secrets<P: AsRef<Path>>(mountpoint: P, secrets: &[BuildSecret]) -> Result<()> {
+    if secrets.is_empty() {
+        return Ok(());
+    }
+
+    let mountpoint = mountpoint.as_ref();
+    let target_dir = mountpoint.join(SECRETS_DIR.strip_prefix('/').unwrap());
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("Failed to create {}", target_dir.display()))?;
+
+    nix::mount::mount::<_, _, str, str>(
+        Some("tmpfs"),
+        &target_dir,
+        Some("tmpfs"),
+        nix::mount::MsFlags::empty(),
+        Some("size=1048576,mode=0755"),
+    )
+    .with_context(|| format!("Failed to mount tmpfs on {}", target_dir.display()))?;
+
+    for secret in secrets {
+        let content = fs::read(&secret.src).with_context(|| {
+            format!(
+                "Failed to read secret `{}` from {}",
+                secret.id,
+                secret.src.display()
+            )
+        })?;
+
+        let target_file = target_dir.join(&secret.id);
+        fs::write(&target_file, &content).with_context(|| {
+            format!(
+                "Failed to write secret `{}` to {}",
+                secret.id,
+                target_file.display()
+            )
+        })?;
+
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&target_file, fs::Permissions::from_mode(0o400))
+            .with_context(|| format!("Failed to set permissions on {}", target_file.display()))?;
+    }
+
+    Ok(())
+}
+
+pub fn prepare_ssh<P: AsRef<Path>>(mountpoint: P, ssh_agents: &[BuildSshAgent]) -> Result<()> {
+    if ssh_agents.is_empty() {
+        return Ok(());
+    }
+
+    let mountpoint = mountpoint.as_ref();
+    let target_dir = mountpoint.join(RKFORGE_SSH_DIR.strip_prefix('/').unwrap());
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("Failed to create {}", target_dir.display()))?;
+
+    nix::mount::mount::<_, _, str, str>(
+        Some("tmpfs"),
+        &target_dir,
+        Some("tmpfs"),
+        nix::mount::MsFlags::empty(),
+        Some("size=1048576,mode=0755"),
+    )
+    .with_context(|| format!("Failed to mount tmpfs on {}", target_dir.display()))?;
+
+    for (idx, agent) in ssh_agents.iter().enumerate() {
+        let target_socket = target_dir.join(format!("ssh_agent.{idx}"));
+
+        fs::write(&target_socket, b"").with_context(|| {
+            format!(
+                "Failed to create placeholder for ssh agent `{}` at {}",
+                agent.id,
+                target_socket.display()
+            )
+        })?;
+
+        nix::mount::mount::<_, _, str, str>(
+            Some(&agent.socket_path),
+            &target_socket,
+            None,
+            nix::mount::MsFlags::MS_BIND,
+            None,
+        )
+        .with_context(|| {
+            format!(
+                "Failed to bind mount ssh agent `{}` from {} to {}",
+                agent.id,
+                agent.socket_path.display(),
+                target_socket.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn umount_and_remove_dir(path: &Path) -> Result<()> {
+    umount_if_mounted(path)?;
+    if path.exists() {
+        let _ = fs::remove_dir_all(path);
+    }
+    Ok(())
+}
+
+fn remove_temp_file(path: &Path) {
+    if path.exists()
+        && let Err(err) = fs::remove_file(path)
+    {
+        tracing::warn!(
+            error = ?err,
+            path = %path.display(),
+            "Failed to remove temporary file during cleanup"
+        );
+    }
+}
+
 fn cleanup_network<P: AsRef<Path>>(mountpoint: P) -> Result<()> {
     let mountpoint = mountpoint.as_ref();
-    let target_shm = mountpoint.join(SHM_CONFIG.strip_prefix('/').unwrap());
-    umount_if_mounted(&target_shm)?;
 
-    let target_hosts = mountpoint.join(HOSTS_CONFIG.strip_prefix('/').unwrap());
-    umount_if_mounted(&target_hosts)?;
+    umount_and_remove_dir(&mountpoint.join(RKFORGE_SSH_DIR.strip_prefix('/').unwrap()))?;
+    umount_and_remove_dir(&mountpoint.join(SECRETS_DIR.strip_prefix('/').unwrap()))?;
+    umount_if_mounted(&mountpoint.join(SHM_CONFIG.strip_prefix('/').unwrap()))?;
+    umount_if_mounted(&mountpoint.join(HOSTS_CONFIG.strip_prefix('/').unwrap()))?;
+    umount_if_mounted(&mountpoint.join(DNS_CONFIG.strip_prefix('/').unwrap()))?;
 
-    let target_resolv_conf = mountpoint.join(DNS_CONFIG.strip_prefix('/').unwrap());
-    umount_if_mounted(&target_resolv_conf)?;
-
-    let host_hosts_file = runtime_temp_file("hosts");
-    if host_hosts_file.exists()
-        && let Err(err) = fs::remove_file(&host_hosts_file)
-    {
-        tracing::warn!(
-            error = ?err,
-            path = %host_hosts_file.display(),
-            "Failed to remove temporary hosts file during cleanup"
-        );
-    }
-
-    let host_resolv_conf = runtime_temp_file("resolv.conf");
-    if host_resolv_conf.exists()
-        && let Err(err) = fs::remove_file(&host_resolv_conf)
-    {
-        tracing::warn!(
-            error = ?err,
-            path = %host_resolv_conf.display(),
-            "Failed to remove temporary resolv.conf file during cleanup"
-        );
-    }
+    remove_temp_file(&runtime_temp_file("hosts"));
+    remove_temp_file(&runtime_temp_file("resolv.conf"));
     Ok(())
 }
 

--- a/project/rkforge/src/run.rs
+++ b/project/rkforge/src/run.rs
@@ -1,8 +1,10 @@
 use crate::image::build_runtime::{
-    BuildHostEntry, BuildNetworkMode, BuildUlimit, normalize_cgroup_parent,
+    BuildHostEntry, BuildNetworkMode, BuildSecret, BuildSshAgent, BuildUlimit,
+    normalize_cgroup_parent,
 };
 use crate::overlayfs::{
-    bind_mount, do_exec, prepare_hosts, prepare_network, prepare_shm, switch_namespace,
+    bind_mount, do_exec, prepare_hosts, prepare_network, prepare_secrets, prepare_shm, prepare_ssh,
+    switch_namespace,
 };
 use anyhow::{Context, Result, bail};
 use base64::{Engine, engine::general_purpose};
@@ -38,6 +40,10 @@ pub struct ExecInternalArgs {
     pub network: BuildNetworkMode,
     #[arg(long)]
     pub cgroup_parent: Option<String>,
+    #[arg(long)]
+    pub secrets_base64: Option<String>,
+    #[arg(long)]
+    pub ssh_base64: Option<String>,
 }
 
 fn decode_optional_base64_json<T>(value: Option<&str>, arg_name: &str) -> Result<T>
@@ -90,6 +96,11 @@ pub fn exec_internal(args: ExecInternalArgs) -> Result<()> {
     let ulimits: Vec<BuildUlimit> =
         decode_optional_base64_json(args.ulimits_base64.as_deref(), "ulimits-base64")?;
 
+    let secrets: Vec<BuildSecret> =
+        decode_optional_base64_json(args.secrets_base64.as_deref(), "secrets-base64")?;
+    let ssh_agents: Vec<BuildSshAgent> =
+        decode_optional_base64_json(args.ssh_base64.as_deref(), "ssh-base64")?;
+
     bind_mount(mountpoint)?;
     if matches!(
         args.network,
@@ -99,6 +110,8 @@ pub fn exec_internal(args: ExecInternalArgs) -> Result<()> {
     }
     prepare_hosts(mountpoint, &add_hosts)?;
     prepare_shm(mountpoint, args.shm_size)?;
+    prepare_secrets(mountpoint, &secrets)?;
+    prepare_ssh(mountpoint, &ssh_agents)?;
     apply_cgroup_parent(args.cgroup_parent.as_deref())?;
 
     let commands_json = general_purpose::STANDARD

--- a/project/rkforge/src/task.rs
+++ b/project/rkforge/src/task.rs
@@ -1,4 +1,6 @@
-use crate::image::build_runtime::{BuildHostEntry, BuildNetworkMode, BuildUlimit};
+use crate::image::build_runtime::{
+    BuildHostEntry, BuildNetworkMode, BuildSecret, BuildSshAgent, BuildUlimit,
+};
 use crate::overlayfs::MountConfig;
 use anyhow::{Context, Result};
 use base64::{Engine, engine::general_purpose};
@@ -31,6 +33,10 @@ pub struct RunTask {
     pub network_mode: BuildNetworkMode,
     /// Optional cgroup parent for build-time RUN containers.
     pub cgroup_parent: Option<String>,
+    /// Build-time secrets mounted into /run/secrets/<id>.
+    pub secrets: Vec<BuildSecret>,
+    /// SSH agent sockets mounted into /run/rkforge/ssh/ssh_agent.<N>.
+    pub ssh: Vec<BuildSshAgent>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -101,16 +107,32 @@ impl TaskExec for RunTask {
                 .context("Failed to serialize ulimits to json")?;
             Some(general_purpose::STANDARD.encode(ulimits_json))
         };
+        let secrets_base64 = if self.secrets.is_empty() {
+            None
+        } else {
+            let secrets_json = serde_json::to_string(&self.secrets)
+                .context("Failed to serialize secrets to json")?;
+            Some(general_purpose::STANDARD.encode(secrets_json))
+        };
+        let ssh_base64 = if self.ssh.is_empty() {
+            None
+        } else {
+            let ssh_json = serde_json::to_string(&self.ssh)
+                .context("Failed to serialize ssh agents to json")?;
+            Some(general_purpose::STANDARD.encode(ssh_json))
+        };
 
         trace!(
-            "Run commands: {:?}, envp: {:?}, working_dir: {:?}, user: {:?}, add_hosts: {:?}, shm_size: {:?}, ulimits: {:?}",
+            "Run commands: {:?}, envp: {:?}, working_dir: {:?}, user: {:?}, add_hosts: {:?}, shm_size: {:?}, ulimits: {:?}, secrets: {} ssh: {}",
             self.commands,
             self.envp,
             self.working_dir,
             self.user,
             self.add_hosts,
             self.shm_size,
-            self.ulimits
+            self.ulimits,
+            self.secrets.len(),
+            self.ssh.len()
         );
         command
             .arg("--mountpoint")
@@ -144,6 +166,12 @@ impl TaskExec for RunTask {
         }
         if let Some(cgroup_parent) = &self.cgroup_parent {
             command.arg("--cgroup-parent").arg(cgroup_parent);
+        }
+        if let Some(secrets_base64) = &secrets_base64 {
+            command.arg("--secrets-base64").arg(secrets_base64);
+        }
+        if let Some(ssh_base64) = &ssh_base64 {
+            command.arg("--ssh-base64").arg(ssh_base64);
         }
 
         if self.quiet {


### PR DESCRIPTION
- add BuildSecret/BuildSshAgent models and wire them through build context/executor/task
- add --secret and --ssh CLI parsing with validation (secret id traversal guard, ssh unix-socket check)
- pass secrets/ssh into exec-internal via base64 JSON arguments
- prepare runtime mounts for /run/secrets and /run/rkforge/ssh, with tmpfs + bind mounts and cleanup
- set default SSH_AUTH_SOCK for RUN when ssh agents are configured
- add/adjust tests for secret/ssh parsing and related edge cases