### PR TITLE
fix(libfuse-fs): improve async file-lock semantics and unify fallback behavior

### DIFF
--- a/project/libfuse-fs/src/overlayfs/async_io.rs
+++ b/project/libfuse-fs/src/overlayfs/async_io.rs
@@ -846,32 +846,102 @@ impl Filesystem for OverlayFs {
     #[allow(clippy::too_many_arguments)]
     async fn getlk(
         &self,
-        _req: Request,
+        req: Request,
         _inode: Inode,
-        _fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
+        fh: u64,
+        lock_owner: u64,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
     ) -> Result<ReplyLock> {
-        Err(libc::ENOSYS.into())
+        if !self.no_open.load(Ordering::Relaxed) {
+            let handles = self.handles.lock().await;
+            if let Some(hd) = handles.get(&fh)
+                && let Some(ref rh) = hd.real_handle
+            {
+                match rh
+                    .layer
+                    .getlk(
+                        req,
+                        rh.inode,
+                        rh.handle.load(Ordering::Relaxed),
+                        lock_owner,
+                        start,
+                        end,
+                        r#type,
+                        pid,
+                    )
+                    .await
+                {
+                    Ok(reply) => return Ok(reply),
+                    Err(e) => {
+                        // If underlying layer doesn't support locking, fall through to fallback
+                        let errno: i32 = e.into();
+                        if errno != libc::ENOSYS {
+                            return Err(errno.into());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: report no lock conflict
+        Ok(ReplyLock {
+            start: 0,
+            end: 0,
+            r#type: libc::F_UNLCK as u32,
+            pid: 0,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn setlk(
         &self,
-        _req: Request,
+        req: Request,
         _inode: Inode,
-        _fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
-        _block: bool,
+        fh: u64,
+        lock_owner: u64,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
+        block: bool,
     ) -> Result<()> {
-        Err(libc::ENOSYS.into())
+        if !self.no_open.load(Ordering::Relaxed) {
+            let handles = self.handles.lock().await;
+            if let Some(hd) = handles.get(&fh)
+                && let Some(ref rh) = hd.real_handle
+            {
+                match rh
+                    .layer
+                    .setlk(
+                        req,
+                        rh.inode,
+                        rh.handle.load(Ordering::Relaxed),
+                        lock_owner,
+                        start,
+                        end,
+                        r#type,
+                        pid,
+                        block,
+                    )
+                    .await
+                {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        // If underlying layer doesn't support locking, fall through to fallback
+                        let errno: i32 = e.into();
+                        if errno != libc::ENOSYS {
+                            return Err(errno.into());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: silently accept the lock request
+        Ok(())
     }
     /// check file access permissions. This will be called for the `access()` system call. If the
     /// `default_permissions` mount option is given, this method is not be called. This method is

--- a/project/libfuse-fs/src/passthrough/async_io.rs
+++ b/project/libfuse-fs/src/passthrough/async_io.rs
@@ -1875,31 +1875,88 @@ impl Filesystem for PassthroughFs {
     async fn getlk(
         &self,
         _req: Request,
-        _inode: Inode,
-        _fh: u64,
+        inode: Inode,
+        fh: u64,
         _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
     ) -> Result<ReplyLock> {
-        Err(libc::ENOSYS.into())
+        if self.no_open.load(Ordering::Relaxed) {
+            return Err(enosys().into());
+        }
+
+        let data = self.handle_map.get(fh, inode).await?;
+        let mut flock = libc::flock {
+            l_type: r#type as libc::c_short,
+            l_whence: libc::SEEK_SET as libc::c_short,
+            l_start: start as libc::off_t,
+            l_len: if end == u64::MAX {
+                0 // 0 means until EOF
+            } else {
+                end.saturating_sub(start) as libc::off_t
+            },
+            l_pid: pid as libc::pid_t,
+        };
+
+        // SAFETY: We pass a valid fd and a valid pointer to flock.
+        let ret = unsafe { libc::fcntl(data.borrow_fd().as_raw_fd(), libc::F_GETLK, &mut flock) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+
+        Ok(ReplyLock {
+            start: flock.l_start as u64,
+            end: if flock.l_len == 0 {
+                u64::MAX
+            } else {
+                flock.l_start as u64 + flock.l_len as u64
+            },
+            r#type: flock.l_type as u32,
+            pid: flock.l_pid as u32,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn setlk(
         &self,
         _req: Request,
-        _inode: Inode,
-        _fh: u64,
+        inode: Inode,
+        fh: u64,
         _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
-        _block: bool,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
+        block: bool,
     ) -> Result<()> {
-        Err(libc::ENOSYS.into())
+        if self.no_open.load(Ordering::Relaxed) {
+            return Err(enosys().into());
+        }
+
+        let data = self.handle_map.get(fh, inode).await?;
+        let flock = libc::flock {
+            l_type: r#type as libc::c_short,
+            l_whence: libc::SEEK_SET as libc::c_short,
+            l_start: start as libc::off_t,
+            l_len: if end == u64::MAX {
+                0 // 0 means until EOF
+            } else {
+                end.saturating_sub(start) as libc::off_t
+            },
+            l_pid: pid as libc::pid_t,
+        };
+
+        let cmd = if block { libc::F_SETLKW } else { libc::F_SETLK };
+
+        // SAFETY: We pass a valid fd and a valid pointer to flock.
+        let ret = unsafe { libc::fcntl(data.borrow_fd().as_raw_fd(), cmd, &flock) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+
+        Ok(())
     }
 
     /// check file access permissions. This will be called for the `access()` system call. If the

--- a/project/libfuse-fs/src/passthrough/file_handle.rs
+++ b/project/libfuse-fs/src/passthrough/file_handle.rs
@@ -15,7 +15,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 
 #[allow(unused_imports)]
-use tracing::error;
+use tracing::{debug, error};
 use vmm_sys_util::fam::{FamStruct, FamStructWrapper};
 
 use super::EMPTY_CSTR;
@@ -328,7 +328,12 @@ impl OpenableFileHandle {
                 Ok(file)
             } else {
                 let e = io::Error::last_os_error();
-                error!("open_by_handle_at failed error {e:?}");
+                // ESTALE is a recoverable error when file handle becomes stale
+                if e.raw_os_error() == Some(libc::ESTALE) {
+                    debug!("open_by_handle_at: stale file handle (ESTALE)");
+                } else {
+                    error!("open_by_handle_at failed error {e:?}");
+                }
                 Err(e)
             }
         }

--- a/project/libfuse-fs/src/unionfs/async_io.rs
+++ b/project/libfuse-fs/src/unionfs/async_io.rs
@@ -841,32 +841,102 @@ impl Filesystem for OverlayFs {
     #[allow(clippy::too_many_arguments)]
     async fn getlk(
         &self,
-        _req: Request,
+        req: Request,
         _inode: Inode,
-        _fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
+        fh: u64,
+        lock_owner: u64,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
     ) -> Result<ReplyLock> {
-        Err(libc::ENOSYS.into())
+        if !self.no_open.load(Ordering::Relaxed) {
+            let handles = self.handles.lock().await;
+            if let Some(hd) = handles.get(&fh)
+                && let Some(ref rh) = hd.real_handle
+            {
+                match rh
+                    .layer
+                    .getlk(
+                        req,
+                        rh.inode,
+                        rh.handle.load(Ordering::Relaxed),
+                        lock_owner,
+                        start,
+                        end,
+                        r#type,
+                        pid,
+                    )
+                    .await
+                {
+                    Ok(reply) => return Ok(reply),
+                    Err(e) => {
+                        // If underlying layer doesn't support locking, fall through to fallback
+                        let errno: i32 = e.into();
+                        if errno != libc::ENOSYS {
+                            return Err(errno.into());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: report no lock conflict
+        Ok(ReplyLock {
+            start: 0,
+            end: 0,
+            r#type: libc::F_UNLCK as u32,
+            pid: 0,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn setlk(
         &self,
-        _req: Request,
+        req: Request,
         _inode: Inode,
-        _fh: u64,
-        _lock_owner: u64,
-        _start: u64,
-        _end: u64,
-        _type: u32,
-        _pid: u32,
-        _block: bool,
+        fh: u64,
+        lock_owner: u64,
+        start: u64,
+        end: u64,
+        r#type: u32,
+        pid: u32,
+        block: bool,
     ) -> Result<()> {
-        Err(libc::ENOSYS.into())
+        if !self.no_open.load(Ordering::Relaxed) {
+            let handles = self.handles.lock().await;
+            if let Some(hd) = handles.get(&fh)
+                && let Some(ref rh) = hd.real_handle
+            {
+                match rh
+                    .layer
+                    .setlk(
+                        req,
+                        rh.inode,
+                        rh.handle.load(Ordering::Relaxed),
+                        lock_owner,
+                        start,
+                        end,
+                        r#type,
+                        pid,
+                        block,
+                    )
+                    .await
+                {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        // If underlying layer doesn't support locking, fall through to fallback
+                        let errno: i32 = e.into();
+                        if errno != libc::ENOSYS {
+                            return Err(errno.into());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: silently accept the lock request
+        Ok(())
     }
     /// check file access permissions. This will be called for the `access()` system call. If the
     /// `default_permissions` mount option is given, this method is not be called. This method is


### PR DESCRIPTION
1. passthrough: implement getlk/setlk via fcntl, supporting both blocking and non-blocking locks
2. overlayfs/unionfs: forward getlk/setlk to the underlying real handle
3. add compatibility fallback for underlying ENOSYS: getlk returns F_UNLCK, setlk degrades to success
4. downgrade ESTALE in open_by_handle_at to debug logging to reduce false alarms