### PR TITLE
feat(rkforge): harden registry transport config

### DIFF
--- a/project/libfuse-fs/src/overlayfs/mod.rs
+++ b/project/libfuse-fs/src/overlayfs/mod.rs
@@ -279,13 +279,12 @@ impl RealInode {
             Err(e) => {
                 let ioerror: std::io::Error = e.into();
                 match ioerror.raw_os_error() {
-                    Some(raw_error) => {
-                        if raw_error == libc::ENOSYS {
-                            // We can still call readdir with inode if opendir is not supported in this layer.
-                            ReplyOpen { fh: 0, flags: 0 }
-                        } else {
-                            return Err(e.into());
-                        }
+                    Some(raw_error) if raw_error == libc::ENOSYS => {
+                        // We can still call readdir with inode if opendir is not supported in this layer.
+                        ReplyOpen { fh: 0, flags: 0 }
+                    }
+                    Some(_) => {
+                        return Err(e.into());
                     }
                     None => {
                         return Err(e.into());

--- a/project/libfuse-fs/src/unionfs/mod.rs
+++ b/project/libfuse-fs/src/unionfs/mod.rs
@@ -279,13 +279,12 @@ impl RealInode {
             Err(e) => {
                 let ioerror: std::io::Error = e.into();
                 match ioerror.raw_os_error() {
-                    Some(raw_error) => {
-                        if raw_error == libc::ENOSYS {
-                            // We can still call readdir with inode if opendir is not supported in this layer.
-                            ReplyOpen { fh: 0, flags: 0 }
-                        } else {
-                            return Err(e.into());
-                        }
+                    Some(raw_error) if raw_error == libc::ENOSYS => {
+                        // We can still call readdir with inode if opendir is not supported in this layer.
+                        ReplyOpen { fh: 0, flags: 0 }
+                    }
+                    Some(_) => {
+                        return Err(e.into());
                     }
                     None => {
                         return Err(e.into());

--- a/project/rkforge/src/config/auth.rs
+++ b/project/rkforge/src/config/auth.rs
@@ -1,7 +1,9 @@
 use crate::config::image::CONFIG;
+use crate::registry::{RegistryScheme, parse_registry_host, scheme_for_registry};
 use crate::utils::cli::original_user_config_path;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::Path;
 use std::pin::Pin;
 
@@ -11,9 +13,24 @@ pub struct ImageConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RegistryConfig {
+    #[serde(default, rename = "insecure-registries", alias = "insecure_registries")]
+    pub insecure_registries: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
 pub struct RkforgeConfig {
     #[serde(default)]
     pub entries: Vec<AuthEntry>,
+    #[serde(default)]
+    pub registry: RegistryConfig,
+    #[serde(
+        default,
+        rename = "insecure-registries",
+        alias = "insecure_registries",
+        skip_serializing
+    )]
+    legacy_insecure_registries: Vec<String>,
     #[serde(default)]
     pub image: ImageConfig,
 }
@@ -53,9 +70,12 @@ impl RkforgeConfig {
 pub struct AuthConfig {
     #[serde(default)]
     pub entries: Vec<AuthEntry>,
+    #[serde(default)]
+    pub insecure_registries: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct AuthEntry {
     pub pat: String,
     pub url: String,
@@ -80,7 +100,7 @@ impl AuthConfig {
     }
 
     pub fn find_entry_by_url(&self, url: impl AsRef<str>) -> anyhow::Result<&AuthEntry> {
-        let url = url.as_ref();
+        let url = parse_registry_host(url.as_ref())?;
         self.entries
             .iter()
             .find(|entry| entry.url == url)
@@ -101,13 +121,15 @@ impl AuthConfig {
     /// 1. The URL provided in the `url` parameter, if specified.
     /// 2. The URL from the configuration file, if a single registry is configured.
     /// 3. The default registry URL as a final fallback.
-    pub fn resolve_url(&self, url: Option<impl AsRef<str>>) -> String {
+    pub fn resolve_url(&self, url: Option<impl AsRef<str>>) -> anyhow::Result<String> {
         if let Some(url) = url {
-            return url.as_ref().to_string();
+            return parse_registry_host(url.as_ref());
         }
-        self.single_entry()
-            .map(|entry| entry.url.to_string())
-            .unwrap_or(CONFIG.default_registry.to_string())
+        if let Ok(entry) = self.single_entry() {
+            return Ok(entry.url.to_string());
+        }
+        parse_registry_host(&CONFIG.default_registry)
+            .with_context(|| "failed to normalize default registry")
     }
 
     pub fn with_single_entry<F, R>(&self, f: F) -> anyhow::Result<R>
@@ -126,27 +148,44 @@ impl AuthConfig {
 
     pub fn load() -> anyhow::Result<Self> {
         let config = RkforgeConfig::load()?;
-        Ok(Self {
-            entries: config.entries,
-        })
+        Self::from_rkforge_config(config)
     }
 
     pub fn load_from(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let config = RkforgeConfig::load_from(path)?;
+        Self::from_rkforge_config(config)
+    }
+
+    pub fn insecure_registries(&self) -> &[String] {
+        &self.insecure_registries
+    }
+
+    pub fn registry_scheme(&self, registry: impl AsRef<str>) -> RegistryScheme {
+        scheme_for_registry(registry, &self.insecure_registries)
+    }
+
+    fn from_rkforge_config(config: RkforgeConfig) -> anyhow::Result<Self> {
+        let mut insecure_registries = config.registry.insecure_registries;
+        insecure_registries.extend(config.legacy_insecure_registries);
         Ok(Self {
-            entries: config.entries,
+            entries: normalize_entries(config.entries)?,
+            insecure_registries: normalize_registry_list(
+                insecure_registries,
+                "insecure_registries",
+            )?,
         })
     }
 
     pub fn is_anonymous(&self, url: impl AsRef<str>) -> bool {
-        let url = url.as_ref();
+        let Ok(url) = parse_registry_host(url.as_ref()) else {
+            return true;
+        };
         self.entries.iter().all(|entry| entry.url != url)
     }
 
     pub fn login(pat: impl Into<String>, url: impl Into<String>) -> anyhow::Result<()> {
         let mut config = RkforgeConfig::load()?;
-
-        let url = url.into();
+        let url = parse_registry_host(url.into())?;
         let entry = AuthEntry::new(pat, &url);
         if let Some((idx, _)) = config
             .entries
@@ -157,16 +196,49 @@ impl AuthConfig {
             config.entries.remove(idx);
         }
 
+        config.entries.iter_mut().try_for_each(|entry| {
+            entry.url = parse_registry_host(&entry.url)?;
+            Ok::<(), anyhow::Error>(())
+        })?;
+        config.registry.insecure_registries =
+            normalize_registry_list(config.registry.insecure_registries, "insecure_registries")?;
         config.entries.push(entry);
         config.store()
     }
 
     pub fn logout(url: impl Into<String>) -> anyhow::Result<()> {
         let mut config = RkforgeConfig::load()?;
-        let url = url.into();
+        let url = parse_registry_host(url.into())?;
+        config.registry.insecure_registries =
+            normalize_registry_list(config.registry.insecure_registries, "insecure_registries")?;
         config.entries.retain(|entry| entry.url != url);
         config.store()
     }
+}
+
+fn normalize_entries(entries: Vec<AuthEntry>) -> anyhow::Result<Vec<AuthEntry>> {
+    entries
+        .into_iter()
+        .map(|mut entry| {
+            let raw_url = entry.url.clone();
+            entry.url = parse_registry_host(&entry.url)
+                .with_context(|| format!("invalid registry in entries.url: {raw_url}"))?;
+            Ok(entry)
+        })
+        .collect()
+}
+
+fn normalize_registry_list(values: Vec<String>, field: &str) -> anyhow::Result<Vec<String>> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for value in values {
+        let item = parse_registry_host(&value)
+            .with_context(|| format!("invalid registry in {field}: {value}"))?;
+        if seen.insert(item.clone()) {
+            normalized.push(item);
+        }
+    }
+    Ok(normalized)
 }
 
 pub async fn with_resolved_entry<F, R>(url: Option<impl AsRef<str>>, f: F) -> anyhow::Result<R>
@@ -185,7 +257,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthConfig, ImageConfig, RkforgeConfig};
+    use super::{AuthConfig, ImageConfig, RegistryConfig, RkforgeConfig};
     use std::fs;
     use tempfile::tempdir;
 
@@ -253,5 +325,91 @@ storage = "/data/rkforge"
         let auth = AuthConfig::load_from(&config_path).unwrap();
         assert_eq!(auth.entries.len(), 1);
         assert_eq!(auth.entries[0].url, "example.com");
+    }
+
+    #[test]
+    fn test_insecure_registries_deduped_and_normalized() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("rkforge.toml");
+        fs::write(
+            &config_path,
+            r#"
+[registry]
+insecure-registries = ["Example.com", "example.com", "[::1]", "::1"]
+"#,
+        )
+        .unwrap();
+
+        let auth = AuthConfig::load_from(&config_path).unwrap();
+        assert_eq!(
+            auth.insecure_registries,
+            vec!["example.com".to_string(), "[::1]".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_legacy_top_level_insecure_registries_is_still_loaded() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("rkforge.toml");
+        fs::write(
+            &config_path,
+            r#"
+insecure_registries = ["legacy.example.com:5000"]
+"#,
+        )
+        .unwrap();
+
+        let auth = AuthConfig::load_from(&config_path).unwrap();
+        assert_eq!(
+            auth.insecure_registries,
+            vec!["legacy.example.com:5000".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_registry_table_can_appear_after_entries() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("rkforge.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[entries]]
+pat = "token"
+url = "127.0.0.1:8968"
+
+[image]
+storage = "/data/rkforge"
+
+[registry]
+insecure-registries = ["47.79.87.161:8968"]
+"#,
+        )
+        .unwrap();
+
+        let config = RkforgeConfig::load_from(&config_path).unwrap();
+        assert_eq!(
+            config.registry,
+            RegistryConfig {
+                insecure_registries: vec!["47.79.87.161:8968".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn test_insecure_registries_inside_entry_is_rejected() {
+        let dir = tempdir().unwrap();
+        let config_path = dir.path().join("rkforge.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[entries]]
+pat = "token"
+url = "127.0.0.1:8968"
+insecure-registries = ["47.79.87.161:8968"]
+"#,
+        )
+        .unwrap();
+
+        assert!(AuthConfig::load_from(&config_path).is_err());
     }
 }

--- a/project/rkforge/src/lib.rs
+++ b/project/rkforge/src/lib.rs
@@ -12,6 +12,7 @@ pub mod overlayfs;
 pub mod pod_task;
 pub mod pull;
 mod push;
+mod registry;
 mod repo;
 mod rt;
 pub mod storage;

--- a/project/rkforge/src/login/mod.rs
+++ b/project/rkforge/src/login/mod.rs
@@ -1,67 +1,74 @@
 use crate::config::auth::AuthConfig;
 use crate::login::oauth::OAuthFlow;
 use crate::login::types::{CallbackResponse, RequestClientIdResponse};
+use crate::registry::{
+    RegistryScheme, api_url, effective_skip_tls_verify, parse_registry_host_arg,
+};
 use crate::rt::block_on;
 use crate::utils::cli::RequestBuilderExt;
 use axum::http::HeaderMap;
 use clap::Parser;
 use reqwest::Client;
-use std::sync::OnceLock;
 
 mod oauth;
 mod types;
 
-static CLIENT: OnceLock<Client> = OnceLock::new();
+fn client(skip_tls_verify: bool) -> anyhow::Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert("Accept", "application/json".parse().unwrap());
 
-fn client_ref() -> &'static Client {
-    CLIENT.get_or_init(|| {
-        let mut headers = HeaderMap::new();
-        headers.insert("Accept", "application/json".parse().unwrap());
-
-        Client::builder()
-            .default_headers(headers)
-            .build()
-            .expect("Failed to build client")
-    })
+    Client::builder()
+        .default_headers(headers)
+        .danger_accept_invalid_certs(skip_tls_verify)
+        .build()
+        .map_err(Into::into)
 }
 
 #[derive(Debug, Parser)]
 pub struct LoginArgs {
-    /// URL of the distribution server (optional if only one server is configured)
+    /// Registry host in `host[:port]` format (optional if only one server is configured).
+    #[arg(value_parser = parse_registry_host_arg)]
     url: Option<String>,
-    /// Github OAuth app client id (required for first login to this server)
-    client_id: Option<String>,
+    /// Skip TLS certificate verification for HTTPS registry.
+    #[arg(long)]
+    skip_tls_verify: bool,
 }
 
 pub fn login(args: LoginArgs) -> anyhow::Result<()> {
     let config = AuthConfig::load()?;
-
-    let url = match args.url {
-        Some(ref url) => url,
-        None => &config.single_entry()?.url,
+    let registry = match args.url {
+        Some(url) => url,
+        None => config.single_entry()?.url.to_string(),
     };
+    let scheme = config.registry_scheme(&registry);
+    let skip_tls_verify = effective_skip_tls_verify(args.skip_tls_verify, scheme, &registry);
+    let client = client(skip_tls_verify)?;
 
     block_on(async move {
-        let res = request_client_id(url).await?;
+        let res = request_client_id(&client, &registry, scheme).await?;
         let client_id = &res.client_id;
 
         let oauth = OAuthFlow::new(client_id);
         let res = oauth.request_token().await?;
 
-        let req_url = format!("http://{url}/api/v1/auth/github/callback");
-        let res = client_ref()
+        let req_url = api_url(scheme, &registry, "api/v1/auth/github/callback");
+        let res = client
             .post(req_url)
             .json(&res)
             .send_and_json::<CallbackResponse>()
             .await?;
 
-        AuthConfig::login(res.pat, url)?;
+        AuthConfig::login(res.pat, &registry)?;
         println!("Logged in successfully!");
         Ok(())
     })?
 }
 
-async fn request_client_id(url: impl AsRef<str>) -> anyhow::Result<RequestClientIdResponse> {
-    let url = format!("http://{}/api/v1/auth/github/client_id", url.as_ref());
-    client_ref().get(url).send_and_json().await
+async fn request_client_id(
+    client: &Client,
+    registry: impl AsRef<str>,
+    scheme: RegistryScheme,
+) -> anyhow::Result<RequestClientIdResponse> {
+    let url = api_url(scheme, registry, "api/v1/auth/github/client_id");
+    client.get(url).send_and_json().await
 }

--- a/project/rkforge/src/login/oauth.rs
+++ b/project/rkforge/src/login/oauth.rs
@@ -1,12 +1,27 @@
-use crate::login::client_ref;
 use crate::login::types::{
     PollTokenErrorKind, PollTokenOk, PollTokenResponse, RequestCodeResponse,
 };
 use crate::utils::cli::RequestBuilderExt;
+use axum::http::HeaderMap;
+use once_cell::sync::OnceCell;
 use qrcode::QrCode;
 use qrcode::render::unicode;
+use reqwest::Client;
 use serde_json::json;
 use std::time::Duration;
+
+static GITHUB_CLIENT: OnceCell<Client> = OnceCell::new();
+
+fn github_client() -> anyhow::Result<&'static Client> {
+    GITHUB_CLIENT.get_or_try_init(|| {
+        let mut headers = HeaderMap::new();
+        headers.insert("Accept", "application/json".parse().unwrap());
+        Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(Into::into)
+    })
+}
 
 #[derive(Default)]
 pub struct OAuthFlow {
@@ -34,7 +49,7 @@ impl OAuthFlow {
         let url = "https://github.com/login/device/code";
         let scope = "read:user";
 
-        client_ref()
+        github_client()?
             .post(url)
             .form(&json!({
                 "client_id": self.client_id,
@@ -55,7 +70,7 @@ impl OAuthFlow {
         loop {
             tokio::time::sleep(Duration::from_secs(sleep_secs)).await;
 
-            let res = client_ref()
+            let res = github_client()?
                 .post(url)
                 .form(&json!({
                     "client_id": self.client_id,

--- a/project/rkforge/src/logout.rs
+++ b/project/rkforge/src/logout.rs
@@ -1,9 +1,11 @@
 use crate::config::auth::AuthConfig;
+use crate::registry::parse_registry_host_arg;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct LogoutArgs {
-    /// URL of the distribution server
+    /// Registry host in `host[:port]` format.
+    #[arg(value_parser = parse_registry_host_arg)]
     url: Option<String>,
 }
 

--- a/project/rkforge/src/main.rs
+++ b/project/rkforge/src/main.rs
@@ -17,6 +17,7 @@ mod pod_task;
 
 mod pull;
 mod push;
+mod registry;
 mod repo;
 mod rt;
 mod run;

--- a/project/rkforge/src/pull/mod.rs
+++ b/project/rkforge/src/pull/mod.rs
@@ -4,14 +4,15 @@ pub mod media;
 
 use crate::config::auth::AuthConfig;
 use crate::pull::layer::pull_layers;
-use crate::storage::{parse_image_ref, write_manifest};
+use crate::registry::{parse_registry_host_arg, resolve_client_ref_auth as resolve_ref_with_auth};
+use crate::storage::write_manifest;
 use anyhow::Context;
 use anyhow::anyhow;
 use clap::Parser;
-use oci_client::client::ClientConfig;
+use oci_client::Client;
 use oci_client::manifest::OciManifest;
 use oci_client::secrets::RegistryAuth;
-use oci_client::{Client, client};
+use oci_spec::distribution::Reference;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::thread;
@@ -23,13 +24,22 @@ static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 pub struct PullArgs {
     /// Image reference. (e.g "ubuntu:latest" or "me.org/ubuntu:latest")
     image_ref: String,
-    /// URL of the distribution server (optional if only one server is configured)
-    #[arg(long)]
+    /// Registry host in `host[:port]` format.
+    #[arg(long, value_parser = parse_registry_host_arg)]
     url: Option<String>,
+    /// Skip TLS certificate verification for HTTPS registry.
+    #[arg(long)]
+    skip_tls_verify: bool,
 }
 
 pub fn pull(args: PullArgs) -> anyhow::Result<()> {
-    sync_pull_or_get_image(args.image_ref, args.url)?;
+    sync_pull_or_get_image_with_policy_and_output_with_tls(
+        args.image_ref,
+        args.url,
+        false,
+        false,
+        args.skip_tls_verify,
+    )?;
     Ok(())
 }
 
@@ -38,7 +48,7 @@ pub fn sync_pull_or_get_image_with_policy(
     url: Option<impl AsRef<str>>,
     no_cache: bool,
 ) -> anyhow::Result<(PathBuf, Vec<PathBuf>)> {
-    sync_pull_or_get_image_with_policy_and_output(image_ref, url, no_cache, false)
+    sync_pull_or_get_image_with_policy_and_output_with_tls(image_ref, url, no_cache, false, false)
 }
 
 pub fn sync_pull_or_get_image_with_policy_and_output(
@@ -47,24 +57,20 @@ pub fn sync_pull_or_get_image_with_policy_and_output(
     no_cache: bool,
     quiet: bool,
 ) -> anyhow::Result<(PathBuf, Vec<PathBuf>)> {
+    sync_pull_or_get_image_with_policy_and_output_with_tls(image_ref, url, no_cache, quiet, false)
+}
+
+fn sync_pull_or_get_image_with_policy_and_output_with_tls(
+    image_ref: impl AsRef<str>,
+    url: Option<impl AsRef<str>>,
+    no_cache: bool,
+    quiet: bool,
+    skip_tls_verify: bool,
+) -> anyhow::Result<(PathBuf, Vec<PathBuf>)> {
     let image_ref = image_ref.as_ref();
-
-    let auth_config = AuthConfig::load()?;
-
-    let url = auth_config.resolve_url(url);
-
-    let auth_method = match auth_config.find_entry_by_url(&url) {
-        Ok(entry) => RegistryAuth::Bearer(entry.pat.clone()),
-        Err(_) => RegistryAuth::Anonymous,
-    };
-
-    let client_config = ClientConfig {
-        protocol: client::ClientProtocol::Http,
-        ..Default::default()
-    };
-    let client = Client::new(client_config);
-
-    let image_ref = parse_image_ref(url, image_ref, None::<String>)?;
+    let url = url.map(|u| u.as_ref().to_string());
+    let (client, image_ref, auth_method) =
+        resolve_client_ref_auth(image_ref, url, skip_tls_verify)?;
     let do_pull = async move {
         let (manifest, digest) = client
             .pull_manifest(&image_ref, &auth_method)
@@ -141,24 +147,19 @@ pub async fn pull_or_get_image_with_policy(
     url: Option<impl AsRef<str>>,
     no_cache: bool,
 ) -> anyhow::Result<(PathBuf, Vec<PathBuf>)> {
+    pull_or_get_image_with_policy_and_tls(image_ref, url, no_cache, false).await
+}
+
+async fn pull_or_get_image_with_policy_and_tls(
+    image_ref: impl AsRef<str>,
+    url: Option<impl AsRef<str>>,
+    no_cache: bool,
+    skip_tls_verify: bool,
+) -> anyhow::Result<(PathBuf, Vec<PathBuf>)> {
     let image_ref = image_ref.as_ref();
-
-    let auth_config = AuthConfig::load()?;
-
-    let url = auth_config.resolve_url(url);
-
-    let auth_method = match auth_config.find_entry_by_url(&url) {
-        Ok(entry) => RegistryAuth::Bearer(entry.pat.clone()),
-        Err(_) => RegistryAuth::Anonymous,
-    };
-
-    let client_config = ClientConfig {
-        protocol: client::ClientProtocol::Http,
-        ..Default::default()
-    };
-    let client = Client::new(client_config);
-
-    let image_ref = parse_image_ref(url, image_ref, None::<String>)?;
+    let url = url.map(|u| u.as_ref().to_string());
+    let (client, image_ref, auth_method) =
+        resolve_client_ref_auth(image_ref, url, skip_tls_verify)?;
     let (manifest, digest) = client
         .pull_manifest(&image_ref, &auth_method)
         .await
@@ -173,4 +174,14 @@ pub async fn pull_or_get_image_with_policy(
 
     let manifest_path = write_manifest(&image_ref, &manifest, &digest).await?;
     Ok((manifest_path, layers))
+}
+
+fn resolve_client_ref_auth(
+    image_ref: &str,
+    url: Option<String>,
+    skip_tls_verify: bool,
+) -> anyhow::Result<(Client, Reference, RegistryAuth)> {
+    let auth_config = AuthConfig::load()?;
+    let url = auth_config.resolve_url(url)?;
+    resolve_ref_with_auth(&auth_config, &url, image_ref, skip_tls_verify)
 }

--- a/project/rkforge/src/push/mod.rs
+++ b/project/rkforge/src/push/mod.rs
@@ -2,11 +2,14 @@ mod pusher;
 
 use crate::config::auth::AuthConfig;
 use crate::push::pusher::{PushTask, Pusher};
+use crate::registry::{
+    parse_registry_host, parse_registry_host_arg, resolve_client_ref_auth as resolve_ref_with_auth,
+};
 use crate::rt::block_on;
 use crate::storage::{DigestExt, parse_image_ref};
 use anyhow::{Context, bail};
 use clap::Parser;
-use oci_client::client::{ClientConfig, ImageLayer};
+use oci_client::client::ImageLayer;
 use oci_client::manifest::{OciImageIndex, OciManifest};
 use oci_client::secrets::RegistryAuth;
 use oci_client::{Client, client};
@@ -36,19 +39,32 @@ pub struct PushArgs {
     /// Image path (default current directory)
     #[arg(long)]
     path: Option<String>,
-    #[arg(long)]
+    /// Registry host in `host[:port]` format.
+    #[arg(long, value_parser = parse_registry_host_arg)]
     url: Option<String>,
+    /// Skip TLS certificate verification for HTTPS registry.
+    #[arg(long)]
+    skip_tls_verify: bool,
 }
 
 pub fn push(args: PushArgs) -> anyhow::Result<()> {
     let path = args.path.unwrap_or(".".to_string());
-    push_from_layout(args.image_ref, path, args.url)
+    push_from_layout_with_tls(args.image_ref, path, args.url, args.skip_tls_verify)
 }
 
 pub fn push_from_layout(
     image_ref: impl Into<String>,
     path: impl AsRef<Path>,
     url: Option<String>,
+) -> anyhow::Result<()> {
+    push_from_layout_with_tls(image_ref, path, url, false)
+}
+
+fn push_from_layout_with_tls(
+    image_ref: impl Into<String>,
+    path: impl AsRef<Path>,
+    url: Option<String>,
+    skip_tls_verify: bool,
 ) -> anyhow::Result<()> {
     let image_ref = image_ref.into();
     let path = path.as_ref().to_path_buf();
@@ -60,28 +76,20 @@ pub fn push_from_layout(
     let requested_repo = parsed_input_ref.repository().to_string();
 
     let url = match url {
-        Some(url) => auth_config.resolve_url(Some(url)),
-        None if has_explicit_registry(&image_ref) => parsed_input_ref.registry().to_string(),
-        None => auth_config.resolve_url(None::<String>),
+        Some(url) => auth_config.resolve_url(Some(url))?,
+        None if has_explicit_registry(&image_ref) => {
+            parse_registry_host(parsed_input_ref.registry())?
+        }
+        None => auth_config.resolve_url(None::<String>)?,
     };
-
-    let auth_method = auth_config
-        .find_entry_by_url(&url)
-        .map(|entry| RegistryAuth::Bearer(entry.pat.clone()))
-        .unwrap_or(RegistryAuth::Anonymous);
-
-    let client_config = ClientConfig {
-        protocol: client::ClientProtocol::Http,
-        ..Default::default()
-    };
-    let client = Client::new(client_config);
 
     let normalized_image_ref = if let Some(tag) = parsed_input_ref.tag() {
         format!("{requested_repo}:{}", tag)
     } else {
         requested_repo.clone()
     };
-    let image_ref = parse_image_ref(url, normalized_image_ref, None::<String>)?;
+    let (client, image_ref, auth_method) =
+        resolve_ref_with_auth(&auth_config, &url, &normalized_image_ref, skip_tls_verify)?;
     let registry_url = image_ref.registry().to_string();
 
     block_on(async move {

--- a/project/rkforge/src/registry.rs
+++ b/project/rkforge/src/registry.rs
@@ -1,0 +1,202 @@
+use crate::config::auth::AuthConfig;
+use crate::storage::parse_image_ref;
+use anyhow::{Context, bail};
+use oci_client::Client;
+use oci_client::client::{ClientConfig, ClientProtocol};
+use oci_client::secrets::RegistryAuth;
+use oci_spec::distribution::Reference;
+use reqwest::Url;
+use std::net::Ipv6Addr;
+use tracing::warn;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RegistryScheme {
+    Http,
+    Https,
+}
+
+impl RegistryScheme {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RegistryScheme::Http => "http",
+            RegistryScheme::Https => "https",
+        }
+    }
+
+    pub fn to_client_protocol(self) -> ClientProtocol {
+        match self {
+            RegistryScheme::Http => ClientProtocol::Http,
+            RegistryScheme::Https => ClientProtocol::Https,
+        }
+    }
+}
+
+pub fn parse_registry_host(value: impl AsRef<str>) -> anyhow::Result<String> {
+    let value = value.as_ref().trim();
+    if value.is_empty() {
+        bail!("registry must not be empty, expected host[:port]");
+    }
+    if value.contains("://") {
+        bail!(
+            "registry must be host[:port] format (e.g., 'registry.example.com:5000'). \
+Remove 'http://' or 'https://' prefix: {value}"
+        );
+    }
+    if value.contains('/') || value.contains('?') || value.contains('#') {
+        bail!("registry must be host[:port] without path/query/fragment: {value}");
+    }
+
+    let probe = if value.starts_with('[') {
+        format!("https://{value}")
+    } else if value.parse::<Ipv6Addr>().is_ok() {
+        format!("https://[{value}]")
+    } else {
+        format!("https://{value}")
+    };
+
+    let parsed = Url::parse(&probe).with_context(|| {
+        format!(
+            "invalid registry `{value}`, expected host[:port]. \
+For IPv6 with port, use `[addr]:port` (e.g., `[::1]:5000`)"
+        )
+    })?;
+    let host = parsed
+        .host_str()
+        .with_context(|| format!("registry `{value}` is missing host"))?
+        .to_ascii_lowercase();
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        bail!("registry must not contain username or password: {value}");
+    }
+    if parsed.path() != "/" || parsed.query().is_some() || parsed.fragment().is_some() {
+        bail!("registry must be host[:port] without path/query/fragment: {value}");
+    }
+
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    match parsed.port() {
+        Some(port) => Ok(format!("{host}:{port}")),
+        None => Ok(host),
+    }
+}
+
+pub fn parse_registry_host_arg(value: &str) -> Result<String, String> {
+    parse_registry_host(value).map_err(|e| e.to_string())
+}
+
+pub fn is_insecure_registry(registry: impl AsRef<str>, insecure_registries: &[String]) -> bool {
+    insecure_registries
+        .iter()
+        .any(|entry| entry == registry.as_ref())
+}
+
+pub fn scheme_for_registry(
+    registry: impl AsRef<str>,
+    insecure_registries: &[String],
+) -> RegistryScheme {
+    if is_insecure_registry(registry, insecure_registries) {
+        RegistryScheme::Http
+    } else {
+        RegistryScheme::Https
+    }
+}
+
+pub fn api_url(scheme: RegistryScheme, registry: impl AsRef<str>, path: impl AsRef<str>) -> String {
+    format!(
+        "{}://{}/{}",
+        scheme.as_str(),
+        registry.as_ref(),
+        path.as_ref().trim_start_matches('/')
+    )
+}
+
+pub fn effective_skip_tls_verify(
+    skip_tls_verify: bool,
+    scheme: RegistryScheme,
+    registry: impl AsRef<str>,
+) -> bool {
+    if skip_tls_verify && matches!(scheme, RegistryScheme::Http) {
+        warn!(
+            "Ignoring --skip-tls-verify for insecure registry {} (HTTP transport is in use)",
+            registry.as_ref()
+        );
+    }
+    skip_tls_verify && matches!(scheme, RegistryScheme::Https)
+}
+
+pub fn oci_client_for_registry(
+    scheme: RegistryScheme,
+    skip_tls_verify: bool,
+    registry: impl AsRef<str>,
+) -> Client {
+    let accept_invalid_certificates = effective_skip_tls_verify(skip_tls_verify, scheme, registry);
+    let client_config = ClientConfig {
+        protocol: scheme.to_client_protocol(),
+        accept_invalid_certificates,
+        ..Default::default()
+    };
+    Client::new(client_config)
+}
+
+pub fn resolve_client_ref_auth(
+    auth_config: &AuthConfig,
+    registry: impl AsRef<str>,
+    image_ref: impl AsRef<str>,
+    skip_tls_verify: bool,
+) -> anyhow::Result<(Client, Reference, RegistryAuth)> {
+    let registry = parse_registry_host(registry.as_ref())?;
+    let auth_method = match auth_config.find_entry_by_url(&registry) {
+        Ok(entry) => RegistryAuth::Bearer(entry.pat.clone()),
+        Err(_) => RegistryAuth::Anonymous,
+    };
+    let scheme = auth_config.registry_scheme(&registry);
+    let client = oci_client_for_registry(scheme, skip_tls_verify, &registry);
+    let image_ref = parse_image_ref(&registry, image_ref, None::<String>)?;
+    Ok((client, image_ref, auth_method))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_registry_host;
+
+    #[test]
+    fn parse_registry_host_rejects_scheme() {
+        assert!(parse_registry_host("https://example.com").is_err());
+        assert!(parse_registry_host("http://example.com").is_err());
+    }
+
+    #[test]
+    fn parse_registry_host_rejects_path() {
+        assert!(parse_registry_host("example.com/api").is_err());
+    }
+
+    #[test]
+    fn parse_registry_host_accepts_host_and_port() {
+        assert_eq!(parse_registry_host("Example.Com").unwrap(), "example.com");
+        assert_eq!(
+            parse_registry_host("registry.example.com:5000").unwrap(),
+            "registry.example.com:5000"
+        );
+    }
+
+    #[test]
+    fn parse_registry_host_accepts_ipv6() {
+        assert_eq!(parse_registry_host("::1").unwrap(), "[::1]");
+        assert_eq!(parse_registry_host("[::1]").unwrap(), "[::1]");
+        assert_eq!(parse_registry_host("[::1]:5000").unwrap(), "[::1]:5000");
+    }
+
+    #[test]
+    fn parse_registry_host_rejects_userinfo() {
+        assert!(parse_registry_host("user:pass@example.com").is_err());
+    }
+
+    #[test]
+    fn parse_registry_host_rejects_empty_or_port_only() {
+        assert!(parse_registry_host("").is_err());
+        assert!(parse_registry_host(":5000").is_err());
+    }
+}

--- a/project/rkforge/src/repo/mod.rs
+++ b/project/rkforge/src/repo/mod.rs
@@ -1,6 +1,10 @@
 mod types;
 
-use crate::config::auth::{AuthEntry, with_resolved_entry};
+use crate::config::auth::AuthConfig;
+use crate::config::auth::AuthEntry;
+use crate::registry::{
+    RegistryScheme, api_url, effective_skip_tls_verify, parse_registry_host_arg,
+};
 use crate::repo::types::{ListRepoResponse, Visibility};
 use crate::rt::block_on;
 use axum::http::{HeaderMap, StatusCode};
@@ -12,9 +16,12 @@ use serde_json::json;
 
 #[derive(Parser, Debug)]
 pub struct RepoArgs {
-    /// URL of the distribution server (optional if only one server is configured)
-    #[arg(long)]
+    /// Registry host in `host[:port]` format (optional if only one server is configured)
+    #[arg(long, value_parser = parse_registry_host_arg)]
     url: Option<String>,
+    /// Skip TLS certificate verification for HTTPS registry.
+    #[arg(long)]
+    skip_tls_verify: bool,
     #[clap(subcommand)]
     sub: RepoSubArgs,
 }
@@ -31,24 +38,27 @@ enum RepoSubArgs {
 }
 
 pub fn repo(args: RepoArgs) -> anyhow::Result<()> {
+    let auth_config = AuthConfig::load()?;
+    let entry = auth_config.resolve_entry(args.url.as_ref())?.clone();
+    let scheme = auth_config.registry_scheme(&entry.url);
+    let skip_tls_verify = effective_skip_tls_verify(args.skip_tls_verify, scheme, &entry.url);
     block_on(async move {
-        with_resolved_entry(args.url, move |entry| {
-            Box::pin(async move {
-                match args.sub {
-                    RepoSubArgs::List => handle_repo_list(entry).await,
-                    RepoSubArgs::Vis { name, visibility } => {
-                        handle_repo_visibility(entry, name, visibility).await
-                    }
-                }
-            })
-        })
-        .await
+        match args.sub {
+            RepoSubArgs::List => handle_repo_list(&entry, scheme, skip_tls_verify).await,
+            RepoSubArgs::Vis { name, visibility } => {
+                handle_repo_visibility(&entry, scheme, skip_tls_verify, name, visibility).await
+            }
+        }
     })?
 }
 
-async fn handle_repo_list(entry: &AuthEntry) -> anyhow::Result<()> {
-    let client = client_with_authentication(&entry.pat).await?;
-    let url = format!("http://{}/api/v1/repo", entry.url);
+async fn handle_repo_list(
+    entry: &AuthEntry,
+    scheme: RegistryScheme,
+    skip_tls_verify: bool,
+) -> anyhow::Result<()> {
+    let client = client_with_authentication(&entry.pat, skip_tls_verify).await?;
+    let url = api_url(scheme, &entry.url, "api/v1/repo");
 
     let res = send_and_handle_unexpected(client.get(&url))
         .await?
@@ -73,11 +83,17 @@ async fn handle_repo_list(entry: &AuthEntry) -> anyhow::Result<()> {
 
 async fn handle_repo_visibility(
     entry: &AuthEntry,
+    scheme: RegistryScheme,
+    skip_tls_verify: bool,
     name: impl AsRef<str>,
     visibility: Visibility,
 ) -> anyhow::Result<()> {
-    let client = client_with_authentication(&entry.pat).await?;
-    let url = format!("http://{}/api/v1/{}/visibility", entry.url, name.as_ref());
+    let client = client_with_authentication(&entry.pat, skip_tls_verify).await?;
+    let url = api_url(
+        scheme,
+        &entry.url,
+        format!("api/v1/{}/visibility", name.as_ref()),
+    );
 
     send_and_handle_unexpected(client.put(&url).json(&json!({
         "visibility": visibility.to_string(),
@@ -86,12 +102,16 @@ async fn handle_repo_visibility(
     Ok(())
 }
 
-pub async fn client_with_authentication(pat: impl AsRef<str>) -> anyhow::Result<reqwest::Client> {
+pub async fn client_with_authentication(
+    pat: impl AsRef<str>,
+    skip_tls_verify: bool,
+) -> anyhow::Result<reqwest::Client> {
     let mut headers = HeaderMap::new();
     headers.insert("Authorization", format!("Bearer {}", pat.as_ref()).parse()?);
 
     Ok(reqwest::Client::builder()
         .default_headers(headers)
+        .danger_accept_invalid_certs(skip_tls_verify)
         .build()?)
 }
 


### PR DESCRIPTION
- add registry URL/scheme helpers and centralize client/auth resolution
- wire --skip-tls-verify behavior consistently across login/pull/push/repo
- remove unused login client_id arg and improve oauth client init error handling
- improve registry host parsing/messages and add IPv6/normalization tests