### PR TITLE
feat: delegate distribution auth to Next.js program

### DIFF
--- a/project/distribution/.env.example
+++ b/project/distribution/.env.example
@@ -21,6 +21,11 @@ PROFILE=debug
 GITHUB_CLIENT_ID=github_client_id
 GITHUB_CLIENT_SECRET=github_client_secret
 
+# Next.js auth program URL for delegated authentication.
+# When set, token verification is delegated to the Next program,
+# and GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET become optional.
+# NEXT_AUTH_URL=http://localhost:3000
+
 # S3 storage backend (effective only when OCI_REGISTRY_STORAGE=S3)
 # OCI_REGISTRY_S3_BUCKET=my-registry
 # OCI_REGISTRY_S3_REGION=us-east-1

--- a/project/distribution/compose.yaml
+++ b/project/distribution/compose.yaml
@@ -41,6 +41,7 @@ services:
 
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      NEXT_AUTH_URL: ${NEXT_AUTH_URL:-}
     depends_on:
       db:
         condition: service_healthy

--- a/project/distribution/src/api/middleware.rs
+++ b/project/distribution/src/api/middleware.rs
@@ -32,6 +32,8 @@ pub async fn require_authentication(
         &state.config.jwt_secret,
         state.user_storage.as_ref(),
         &state.config.registry_url,
+        &state.http_client,
+        state.config.next_auth_url.as_deref(),
     )
     .await?;
     req.extensions_mut().insert(claims);
@@ -49,6 +51,8 @@ pub async fn populate_oci_claims(
         &state.config.jwt_secret,
         state.user_storage.as_ref(),
         &state.config.registry_url,
+        &state.http_client,
+        state.config.next_auth_url.as_deref(),
     )
     .await;
     match *req.method() {

--- a/project/distribution/src/api/mod.rs
+++ b/project/distribution/src/api/mod.rs
@@ -7,7 +7,7 @@ use crate::api::middleware::{
 use crate::api::v2::probe;
 use crate::domain::user::UserRepository;
 use crate::error::{AppError, OciError};
-use crate::service::auth::{auth, client_id, oauth_callback};
+use crate::service::auth::{auth, client_id, login_url, oauth_callback};
 use crate::service::repo::{change_visibility, list_visible_repos};
 use crate::utils::jwt::{Claims, decode};
 use crate::utils::password::check_password;
@@ -21,6 +21,7 @@ use axum::routing::{get, post, put};
 use axum_extra::TypedHeader;
 use axum_extra::headers::Authorization;
 use axum_extra::headers::authorization::{Basic, Bearer};
+use serde::Deserialize;
 use std::sync::Arc;
 
 pub fn create_router(state: Arc<AppState>) -> Router<()> {
@@ -48,6 +49,7 @@ fn custom_v1_router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     Router::new()
         .route("/auth/{provider}/callback", post(oauth_callback))
         .route("/auth/{provider}/client_id", get(client_id))
+        .route("/auth/next/login_url", get(login_url))
         .merge(v1_router_with_auth(state))
 }
 
@@ -114,16 +116,77 @@ where
     }
 }
 
-async fn extract_claims(
+/// Response from the Next program's token verification endpoint.
+#[derive(Deserialize)]
+pub(crate) struct NextAuthUserInfo {
+    pub username: String,
+}
+
+/// Verify a Bearer token by calling the Next program's `/api/auth/verify` endpoint.
+pub(crate) async fn verify_token_with_next(
+    client: &reqwest::Client,
+    next_auth_url: &str,
+    token: &str,
+) -> Result<Claims, AppError> {
+    let url = format!("{}/api/auth/verify", next_auth_url.trim_end_matches('/'));
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| OciError::Unauthorized {
+            msg: format!("Failed to verify token with auth service: {e}"),
+            auth_url: None,
+        })?;
+
+    if !response.status().is_success() {
+        return Err(OciError::Unauthorized {
+            msg: "Token verification failed".to_string(),
+            auth_url: None,
+        }
+        .into());
+    }
+
+    let user_info: NextAuthUserInfo =
+        response.json().await.map_err(|e| OciError::Unauthorized {
+            msg: format!("Invalid response from auth service: {e}"),
+            auth_url: None,
+        })?;
+
+    Ok(Claims {
+        sub: user_info.username,
+        exp: 0,
+    })
+}
+
+pub(crate) async fn extract_claims(
     auth: Option<AuthHeader>,
     jwt_secret: impl AsRef<str>,
     user_storage: &dyn UserRepository,
     auth_url: impl AsRef<str>,
+    http_client: &reqwest::Client,
+    next_auth_url: Option<&str>,
 ) -> Result<Claims, AppError> {
     match auth {
         Some(auth) => match auth {
-            AuthHeader::Bearer(bearer) => decode(jwt_secret, bearer.token()),
+            AuthHeader::Bearer(bearer) => {
+                if let Some(next_url) = next_auth_url {
+                    // Delegate token verification to the Next program.
+                    verify_token_with_next(http_client, next_url, bearer.token()).await
+                } else {
+                    // Fallback: decode JWT locally.
+                    decode(jwt_secret, bearer.token())
+                }
+            }
             AuthHeader::Basic(basic) => {
+                if next_auth_url.is_some() {
+                    return Err(OciError::Unauthorized {
+                        msg: "Basic auth is not supported with delegated authentication"
+                            .to_string(),
+                        auth_url: Some(auth_url.as_ref().to_string()),
+                    }
+                    .into());
+                }
                 let user = user_storage.query_user_by_name(basic.username()).await?;
                 check_password(&user.salt, &user.password, basic.password())?;
                 Ok(Claims {
@@ -137,5 +200,73 @@ async fn extract_claims(
             auth_url: Some(auth_url.as_ref().to_string()),
         }
         .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that verify_token_with_next successfully returns claims
+    /// when the Next program responds with valid user info.
+    #[tokio::test]
+    async fn verify_token_with_next_success() {
+        let mock_server = axum::Router::new().route(
+            "/api/auth/verify",
+            axum::routing::get(|| async { Json(serde_json::json!({ "username": "testuser" })) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, mock_server).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let result =
+            verify_token_with_next(&client, &format!("http://{addr}"), "valid-token").await;
+
+        let claims = result.unwrap();
+        assert_eq!(claims.sub, "testuser");
+    }
+
+    /// Test that verify_token_with_next returns an error
+    /// when the Next program responds with 401.
+    #[tokio::test]
+    async fn verify_token_with_next_unauthorized() {
+        let mock_server = axum::Router::new().route(
+            "/api/auth/verify",
+            axum::routing::get(|| async { (axum::http::StatusCode::UNAUTHORIZED, "Unauthorized") }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, mock_server).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let result =
+            verify_token_with_next(&client, &format!("http://{addr}"), "invalid-token").await;
+
+        assert!(result.is_err());
+    }
+
+    /// Test that verify_token_with_next trims trailing slashes from the URL.
+    #[tokio::test]
+    async fn verify_token_with_next_trims_trailing_slash() {
+        let mock_server = axum::Router::new().route(
+            "/api/auth/verify",
+            axum::routing::get(|| async { Json(serde_json::json!({ "username": "slashuser" })) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, mock_server).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let result = verify_token_with_next(&client, &format!("http://{addr}/"), "token").await;
+
+        let claims = result.unwrap();
+        assert_eq!(claims.sub, "slashuser");
     }
 }

--- a/project/distribution/src/config.rs
+++ b/project/distribution/src/config.rs
@@ -28,8 +28,10 @@ pub struct Config {
     pub jwt_secret: String,
     pub jwt_lifetime_secs: i64,
 
-    pub github_client_id: String,
-    pub github_client_secret: String,
+    pub github_client_id: Option<String>,
+    pub github_client_secret: Option<String>,
+
+    pub next_auth_url: Option<String>,
 
     pub s3_config: Option<S3Config>,
 }
@@ -138,8 +140,22 @@ pub async fn validate_config(args: &Args) -> Config {
     .unwrap();
     let jwt_lifetime_secs =
         must_set("JWT_LIFETIME_SECONDS", &mut validation_errors, Some(3600)).unwrap();
-    let github_client_id = must_set("GITHUB_CLIENT_ID", &mut validation_errors, None);
-    let github_client_secret = must_set("GITHUB_CLIENT_SECRET", &mut validation_errors, None);
+
+    let next_auth_url = std::env::var("NEXT_AUTH_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    // GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are only required when NEXT_AUTH_URL is not set.
+    let (github_client_id, github_client_secret) = if next_auth_url.is_some() {
+        (
+            std::env::var("GITHUB_CLIENT_ID").ok(),
+            std::env::var("GITHUB_CLIENT_SECRET").ok(),
+        )
+    } else {
+        let id = must_set("GITHUB_CLIENT_ID", &mut validation_errors, None);
+        let secret = must_set("GITHUB_CLIENT_SECRET", &mut validation_errors, None);
+        (id, secret)
+    };
 
     let db_url = match std::env::var("DATABASE_URL") {
         Ok(url) => url,
@@ -172,8 +188,9 @@ pub async fn validate_config(args: &Args) -> Config {
         db_url,
         jwt_secret,
         jwt_lifetime_secs,
-        github_client_id: github_client_id.unwrap(),
-        github_client_secret: github_client_secret.unwrap(),
+        github_client_id,
+        github_client_secret,
+        next_auth_url: args.next_auth_url.clone(),
         s3_config,
     }
 }

--- a/project/distribution/src/service/auth.rs
+++ b/project/distribution/src/service/auth.rs
@@ -1,14 +1,12 @@
+use crate::api::{AuthHeader, verify_token_with_next};
 use crate::domain::user::User;
 use crate::error::{AppError, BusinessError, InternalError, MapToAppError};
 use crate::utils::jwt::gen_token;
 use crate::utils::password::{check_password, gen_password, gen_salt, hash_password};
 use crate::utils::state::AppState;
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::response::IntoResponse;
-use axum_extra::TypedHeader;
-use axum_extra::headers::Authorization;
-use axum_extra::headers::authorization::Basic;
 use chrono::Utc;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -144,11 +142,31 @@ pub struct AuthResponse {
 
 pub(crate) async fn auth(
     State(state): State<Arc<AppState>>,
-    auth: Option<TypedHeader<Authorization<Basic>>>,
+    auth: Option<AuthHeader>,
 ) -> Result<impl IntoResponse, AppError> {
     let token = match auth {
-        Some(auth) => {
-            let username = auth.username();
+        Some(AuthHeader::Bearer(bearer)) => {
+            if let Some(next_url) = &state.config.next_auth_url {
+                // Verify the bearer token with the Next program.
+                let claims =
+                    verify_token_with_next(&state.http_client, next_url, bearer.token()).await?;
+                gen_token(
+                    state.config.jwt_lifetime_secs,
+                    &state.config.jwt_secret,
+                    &claims.sub,
+                )
+            } else {
+                // Fallback: treat as local JWT.
+                let claims = crate::utils::jwt::decode(&state.config.jwt_secret, bearer.token())?;
+                gen_token(
+                    state.config.jwt_lifetime_secs,
+                    &state.config.jwt_secret,
+                    &claims.sub,
+                )
+            }
+        }
+        Some(AuthHeader::Basic(basic_header)) => {
+            let username = basic_header.username();
             let user = state.user_storage.query_user_by_name(username).await?;
             let canonical_username = canonical_namespace(&user.username);
             let token = gen_token(
@@ -159,7 +177,7 @@ pub(crate) async fn auth(
             {
                 // Check password is a rather time-consuming operation. So it should be executed in `spawn_blocking`.
                 tokio::task::spawn_blocking(move || {
-                    check_password(&user.salt, &user.password, auth.password())
+                    check_password(&user.salt, &user.password, basic_header.password())
                 })
                 .await
                 .map_err(|e| InternalError::Others(e.to_string()))??;
@@ -178,6 +196,36 @@ pub(crate) async fn auth(
         expires_in: state.config.jwt_lifetime_secs,
         issued_at: Utc::now().to_rfc3339(),
     }))
+}
+
+#[derive(Deserialize)]
+pub struct LoginUrlQuery {
+    callback_url: String,
+}
+
+/// Returns the Next program's login URL for browser-based authentication.
+pub async fn login_url(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<LoginUrlQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let next_auth_url = state
+        .config
+        .next_auth_url
+        .as_deref()
+        .ok_or_else(|| BusinessError::BadRequest("Next auth is not configured".to_string()))?;
+
+    let base = next_auth_url.trim_end_matches('/');
+    let mut url = reqwest::Url::parse(&format!("{base}/auth/login")).map_err(|e| {
+        InternalError::Others(format!(
+            "Failed to construct login URL from NEXT_AUTH_URL: {e}"
+        ))
+    })?;
+    url.query_pairs_mut()
+        .append_pair("callback_url", &params.callback_url);
+
+    Ok(Json(json!({
+        "login_url": url.to_string(),
+    })))
 }
 
 pub async fn client_id(
@@ -223,5 +271,29 @@ mod tests {
     #[test]
     fn canonical_namespace_is_lowercase() {
         assert_eq!(canonical_namespace("LingBou"), "lingbou");
+    }
+
+    #[test]
+    fn login_url_constructs_correct_url() {
+        let next_auth_url = "https://auth.example.com";
+        let callback_url = "http://127.0.0.1:12345/callback";
+
+        let base = next_auth_url.trim_end_matches('/');
+        let mut url = reqwest::Url::parse(&format!("{base}/auth/login")).unwrap();
+        url.query_pairs_mut()
+            .append_pair("callback_url", callback_url);
+
+        let result = url.to_string();
+        assert!(result.starts_with("https://auth.example.com/auth/login?"));
+        assert!(result.contains("callback_url="));
+        assert!(result.contains("127.0.0.1"));
+    }
+
+    #[test]
+    fn login_url_trims_trailing_slash() {
+        let next_auth_url = "https://auth.example.com/";
+        let base = next_auth_url.trim_end_matches('/');
+        let url = reqwest::Url::parse(&format!("{base}/auth/login")).unwrap();
+        assert_eq!(url.path(), "/auth/login");
     }
 }

--- a/project/distribution/src/utils/cli.rs
+++ b/project/distribution/src/utils/cli.rs
@@ -80,4 +80,9 @@ pub(crate) struct Args {
     /// Allow plain HTTP (only for dev/testing)
     #[arg(long, env = "OCI_REGISTRY_S3_ALLOW_HTTP", default_value_t = false)]
     pub(crate) s3_allow_http: bool,
+
+    /// Next.js auth program URL for delegated authentication.
+    /// When set, token verification is delegated to the Next program.
+    #[arg(long, env = "NEXT_AUTH_URL")]
+    pub(crate) next_auth_url: Option<String>,
 }

--- a/project/distribution/src/utils/state.rs
+++ b/project/distribution/src/utils/state.rs
@@ -21,6 +21,7 @@ pub struct AppState {
     pub user_storage: Arc<dyn UserRepository>,
     pub repo_storage: Arc<dyn RepoRepository>,
     pub config: Arc<Config>,
+    pub http_client: reqwest::Client,
 }
 
 impl AppState {
@@ -47,6 +48,7 @@ impl AppState {
             config: Arc::new(config),
             user_storage: Arc::new(PgUserRepository::new(pool.clone())),
             repo_storage: Arc::new(PgRepoRepository::new(pool)),
+            http_client: reqwest::Client::new(),
         })
     }
 

--- a/project/distribution/tests/test_next_auth_integration.rs
+++ b/project/distribution/tests/test_next_auth_integration.rs
@@ -1,0 +1,243 @@
+//! Integration tests for the Next.js auth delegation flow.
+//!
+//! These tests spin up:
+//! 1. A mock "Next program" that exposes `/api/auth/verify` and `/auth/login`
+//! 2. Simulate the distribution server's `verify_token_with_next` and `login_url` logic
+//!
+//! Run with: `cargo test -p distribution --test test_next_auth_integration`
+
+use axum::Json;
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::net::TcpListener;
+
+// ---------- mock Next program ----------
+
+/// Mock Next program: verifies bearer tokens and returns user info.
+fn mock_next_app() -> axum::Router {
+    axum::Router::new()
+        .route("/api/auth/verify", axum::routing::get(mock_verify))
+        .route("/auth/login", axum::routing::get(mock_login_page))
+}
+
+async fn mock_verify(
+    headers: axum::http::HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth = headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if let Some(token) = auth.strip_prefix("Bearer ") {
+        if token == "valid-next-token" {
+            return Ok(Json(json!({ "username": "nextuser" })));
+        }
+    }
+    Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()))
+}
+
+#[derive(Deserialize)]
+struct LoginPageQuery {
+    callback_url: String,
+}
+
+async fn mock_login_page(Query(q): Query<LoginPageQuery>) -> impl IntoResponse {
+    // In real flow, the user authenticates here and is redirected.
+    // We just return the callback_url for test verification.
+    Json(json!({
+        "message": "Login page rendered",
+        "callback_url": q.callback_url,
+    }))
+}
+
+// ---------- helpers ----------
+
+async fn start_mock_next() -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, mock_next_app()).await.unwrap();
+    });
+    // Small delay to ensure server is ready.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (url, handle)
+}
+
+// ---------- tests ----------
+
+/// Test: Distribution delegates bearer token verification to Next program.
+/// Simulates: Distribution receives Bearer token → calls Next /api/auth/verify → gets username.
+#[tokio::test]
+async fn distribution_delegates_token_to_next_program() {
+    let (next_url, _handle) = start_mock_next().await;
+    let client = Client::new();
+
+    // Simulate what verify_token_with_next does:
+    let verify_url = format!("{next_url}/api/auth/verify");
+    let resp = client
+        .get(&verify_url)
+        .header("Authorization", "Bearer valid-next-token")
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.status().is_success());
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["username"], "nextuser");
+}
+
+/// Test: Distribution rejects invalid tokens via Next program.
+#[tokio::test]
+async fn distribution_rejects_invalid_token_via_next() {
+    let (next_url, _handle) = start_mock_next().await;
+    let client = Client::new();
+
+    let verify_url = format!("{next_url}/api/auth/verify");
+    let resp = client
+        .get(&verify_url)
+        .header("Authorization", "Bearer bad-token")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Test: Distribution returns login URL from Next program.
+/// Simulates: rkforge calls GET /api/v1/auth/next/login_url?callback_url=...
+/// → Distribution constructs {NEXT_AUTH_URL}/auth/login?callback_url=...
+#[tokio::test]
+async fn distribution_constructs_next_login_url() {
+    let (next_url, _handle) = start_mock_next().await;
+    let callback_url = "http://127.0.0.1:12345/callback";
+
+    // Replicate the login_url construction logic from service/auth.rs
+    let base = next_url.trim_end_matches('/');
+    let mut url = reqwest::Url::parse(&format!("{base}/auth/login")).unwrap();
+    url.query_pairs_mut()
+        .append_pair("callback_url", callback_url);
+
+    let result = url.to_string();
+    assert!(result.contains("/auth/login?"));
+    assert!(result.contains("callback_url="));
+    assert!(result.contains("127.0.0.1%3A12345")); // URL-encoded colon
+
+    // Verify the constructed URL is actually accessible
+    let client = Client::new();
+    let resp = client.get(&result).send().await.unwrap();
+    assert!(resp.status().is_success());
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["callback_url"], callback_url);
+}
+
+/// Test: Full rkforge callback flow.
+/// Simulates: Next program redirects to rkforge's local callback → rkforge receives token.
+#[tokio::test]
+async fn rkforge_callback_receives_token() {
+    use std::sync::Arc;
+    use tokio::sync::{Mutex, Notify};
+
+    // Start the rkforge callback server (same logic as try_next_login)
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let token_store: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let notify = Arc::new(Notify::new());
+
+    let ts = token_store.clone();
+    let nt = notify.clone();
+
+    #[derive(Deserialize)]
+    struct CallbackQuery {
+        token: String,
+    }
+
+    let app = axum::Router::new().route(
+        "/callback",
+        axum::routing::get(move |Query(q): Query<CallbackQuery>| {
+            let ts = ts.clone();
+            let nt = nt.clone();
+            async move {
+                *ts.lock().await = Some(q.token);
+                nt.notify_one();
+                axum::response::Html("<h1>Login successful!</h1>")
+            }
+        }),
+    );
+
+    let server_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    // Simulate the Next program redirecting the browser to the callback
+    let client = Client::new();
+    let callback_url = format!("http://127.0.0.1:{port}/callback?token=my-next-jwt-token");
+    let resp = client.get(&callback_url).send().await.unwrap();
+    assert!(resp.status().is_success());
+
+    // Wait for the notification
+    tokio::time::timeout(std::time::Duration::from_secs(5), notify.notified())
+        .await
+        .expect("callback should have been received within 5 seconds");
+
+    let received_token = token_store.lock().await.take();
+    assert_eq!(received_token, Some("my-next-jwt-token".to_string()));
+
+    server_handle.abort();
+}
+
+/// Test: End-to-end flow simulation.
+/// Simulates the entire auth chain:
+///   rkforge → Distribution (login_url) → Next (login) → callback → token saved
+///   rkforge → Distribution (push with token) → Next (verify) → success
+#[tokio::test]
+async fn end_to_end_auth_flow_simulation() {
+    let (next_url, _handle) = start_mock_next().await;
+    let client = Client::new();
+
+    // Step 1: rkforge requests login URL from distribution
+    // (Distribution constructs: {NEXT_AUTH_URL}/auth/login?callback_url=...)
+    let callback_url = "http://127.0.0.1:19999/callback";
+    let base = next_url.trim_end_matches('/');
+    let mut login_url = reqwest::Url::parse(&format!("{base}/auth/login")).unwrap();
+    login_url
+        .query_pairs_mut()
+        .append_pair("callback_url", callback_url);
+
+    // Step 2: Verify the login URL is valid and accessible
+    let resp = client.get(login_url.as_str()).send().await.unwrap();
+    assert!(resp.status().is_success());
+
+    // Step 3: Simulate "user logged in, Next sends token to callback"
+    // In real flow, Next would redirect the browser to callback_url?token=xxx
+    let token = "valid-next-token";
+
+    // Step 4: rkforge uses the token for push/pull
+    // Distribution verifies the token with Next
+    let verify_url = format!("{next_url}/api/auth/verify");
+    let resp = client
+        .get(&verify_url)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.status().is_success());
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["username"], "nextuser");
+
+    // Step 5: Verify that invalid tokens are rejected
+    let resp = client
+        .get(&verify_url)
+        .header("Authorization", "Bearer stolen-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/project/rkforge/src/login/mod.rs
+++ b/project/rkforge/src/login/mod.rs
@@ -1,6 +1,8 @@
 use crate::config::auth::AuthConfig;
 use crate::login::oauth::OAuthFlow;
-use crate::login::types::{CallbackResponse, RequestClientIdResponse};
+use crate::login::types::{
+    CallbackResponse, LoginUrlResponse, NextCallbackQuery, RequestClientIdResponse,
+};
 use crate::registry::{
     RegistryScheme, api_url, effective_skip_tls_verify, parse_registry_host_arg,
 };
@@ -9,6 +11,8 @@ use crate::utils::cli::RequestBuilderExt;
 use axum::http::HeaderMap;
 use clap::Parser;
 use reqwest::Client;
+use std::sync::Arc;
+use tokio::sync::{Mutex, Notify};
 
 mod oauth;
 mod types;
@@ -45,6 +49,19 @@ pub fn login(args: LoginArgs) -> anyhow::Result<()> {
     let client = client(skip_tls_verify)?;
 
     block_on(async move {
+        // Try Next program auth flow first.
+        match try_next_login(&client, &registry, scheme).await {
+            Ok(token) => {
+                AuthConfig::login(token, &registry)?;
+                println!("Logged in successfully!");
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::debug!("Next auth flow unavailable, falling back to GitHub OAuth: {e}");
+            }
+        }
+
+        // Fallback to GitHub OAuth flow.
         let res = request_client_id(&client, &registry, scheme).await?;
         let client_id = &res.client_id;
 
@@ -62,6 +79,105 @@ pub fn login(args: LoginArgs) -> anyhow::Result<()> {
         println!("Logged in successfully!");
         Ok(())
     })?
+}
+
+/// Attempt browser-based login via the Next program.
+///
+/// 1. Start a local HTTP server to receive the callback.
+/// 2. Request the login URL from the distribution server.
+/// 3. Open the browser for the user to authenticate.
+/// 4. Wait for the callback with the token.
+async fn try_next_login(
+    client: &Client,
+    registry: &str,
+    scheme: RegistryScheme,
+) -> anyhow::Result<String> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let callback_url = format!("http://127.0.0.1:{port}/callback");
+
+    // Request login URL from distribution.
+    let url = api_url(scheme, registry, "api/v1/auth/next/login_url");
+    let res: LoginUrlResponse = client
+        .get(url)
+        .query(&[("callback_url", &callback_url)])
+        .send_and_json()
+        .await?;
+
+    println!("Open the following URL in your browser to log in:");
+    println!("  {}", res.login_url);
+    try_open_browser(&res.login_url);
+
+    // Shared storage for the received token.
+    let token_store: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let notify = Arc::new(Notify::new());
+
+    let ts = token_store.clone();
+    let nt = notify.clone();
+
+    let app = axum::Router::new().route(
+        "/callback",
+        axum::routing::get(
+            move |axum::extract::Query(q): axum::extract::Query<NextCallbackQuery>| {
+                let ts = ts.clone();
+                let nt = nt.clone();
+                async move {
+                    *ts.lock().await = Some(q.token);
+                    nt.notify_one();
+                    axum::response::Html(
+                        "<html><body><h1>Login successful!</h1>\
+                             <p>You can close this window and return to the terminal.</p>\
+                             </body></html>",
+                    )
+                }
+            },
+        ),
+    );
+
+    // Wait for the callback with a 5-minute timeout.
+    let server_handle = tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::warn!("Callback server error: {e}");
+        }
+    });
+
+    let timed_out = tokio::select! {
+        _ = notify.notified() => false,
+        _ = tokio::time::sleep(std::time::Duration::from_secs(300)) => true,
+    };
+
+    // Shut down the callback server.
+    server_handle.abort();
+
+    if timed_out {
+        anyhow::bail!("Login timed out after 5 minutes");
+    }
+
+    token_store
+        .lock()
+        .await
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("No token received"))
+}
+
+/// Try to open a URL in the system browser.
+/// Failures are intentionally ignored because the URL is also printed
+/// to the terminal so the user can open it manually.
+fn try_open_browser(url: &str) {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open").arg(url).spawn();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = std::process::Command::new("cmd")
+            .args(["/C", "start", url])
+            .spawn();
+    }
 }
 
 async fn request_client_id(

--- a/project/rkforge/src/login/types.rs
+++ b/project/rkforge/src/login/types.rs
@@ -48,3 +48,15 @@ pub enum PollTokenErrorKind {
 pub struct RequestClientIdResponse {
     pub client_id: String,
 }
+
+/// Response from the distribution's `/api/v1/auth/next/login_url` endpoint.
+#[derive(Deserialize)]
+pub struct LoginUrlResponse {
+    pub login_url: String,
+}
+
+/// Query parameters received by the local callback server after browser login.
+#[derive(Deserialize)]
+pub struct NextCallbackQuery {
+    pub token: String,
+}


### PR DESCRIPTION
https://github.com/rk8s-dev/rk8s/issues/522 （待领取）
## 整体认证流程
```
rkforge login
  → GET /api/v1/auth/next/login_url?callback_url=http://127.0.0.1:{port}/callback
  → Distribution 拼接 {NEXT_AUTH_URL}/auth/login?callback_url=...
  → 浏览器打开 Next 登录页
  → 用户登录后 Next 重定向到 callback_url?token=xxx
  → rkforge 本地回调服务器收到 token，保存到配置文件

rkforge push/pull（带 token）
  → 请求 Distribution，携带 Authorization: ******
  → Distribution 收到请求，调 GET {NEXT_AUTH_URL}/api/auth/verify（带 ******
  → Next 验证 token，返回 {"username": "..."}
  → Distribution 用 username 生成内部 JWT，完成后续操作
```
## 测试：
<img width="1720" height="1042" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/0b703eee-ace0-419b-a91b-4f8a961063c1" />
<img width="2260" height="1520" alt="image" src="https://github.com/user-attachments/assets/295e1cd3-f654-4169-8439-9a8674f1728d" />

测试脚本位于：https://github.com/lhpqaq/rk8s/blob/r2cn/auth-test/project/distribution/tests/test_next_auth_e2e.sh