### PR TITLE
fix(slayerfs): separate xfstests test and scratch mount identities

### DIFF
--- a/project/slayerfs/src/fuse/mod.rs
+++ b/project/slayerfs/src/fuse/mod.rs
@@ -204,7 +204,7 @@ where
         let attr = vfs_to_fuse_attr(&vattr, &req);
         // Keep generation at 0 and set TTL to 1s (tunable)
         Ok(ReplyEntry {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
             generation: 0,
         })
@@ -287,6 +287,8 @@ where
             out
         };
 
+        let _ = self.update_atime(ino as i64).await;
+
         Ok(ReplyData {
             data: Bytes::from(data),
         })
@@ -354,7 +356,7 @@ where
 
         let attr = vfs_to_fuse_attr(&vattr, &req);
         Ok(ReplyAttr {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
         })
     }
@@ -381,7 +383,7 @@ where
             };
             let attr = vfs_to_fuse_attr(&vattr, &req);
             return Ok(ReplyAttr {
-                ttl: Duration::from_secs(1),
+                ttl: Duration::ZERO,
                 attr,
             });
         }
@@ -394,7 +396,7 @@ where
 
         let attr = vfs_to_fuse_attr(&vattr, &req);
         Ok(ReplyAttr {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
         })
     }
@@ -482,7 +484,7 @@ where
         _lock_owner: u64,
     ) -> FuseResult<ReplyDirectoryPlus<BoxStream<'a, FuseResult<DirectoryEntryPlus>>>> {
         debug!(unique = req.unique, ino, fh, offset, "fuse.readdirplus");
-        let ttl = Duration::from_secs(1);
+        let ttl = Duration::ZERO;
         let mut all: Vec<DirectoryEntryPlus> = Vec::new();
 
         // Try to use handle first
@@ -674,7 +676,7 @@ where
 
         let attr = vfs_to_fuse_attr(&vattr, &req);
         Ok(ReplyEntry {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
             generation: 0,
         })
@@ -728,7 +730,7 @@ where
         };
         let attr = vfs_to_fuse_attr(&vattr, &req);
         Ok(ReplyEntry {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
             generation: 0,
         })
@@ -784,7 +786,7 @@ where
             .map_err(Into::<Errno>::into)?;
 
         Ok(ReplyCreated {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr,
             generation: 0,
             fh,
@@ -851,7 +853,7 @@ where
 
         let fuse_attr = vfs_to_fuse_attr(&attr, &req);
         Ok(ReplyEntry {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr: fuse_attr,
             generation: 0,
         })
@@ -908,7 +910,7 @@ where
             .unwrap_or(vattr);
 
         Ok(ReplyEntry {
-            ttl: Duration::from_secs(1),
+            ttl: Duration::ZERO,
             attr: vfs_to_fuse_attr(&attr, &req),
             generation: 0,
         })

--- a/project/slayerfs/src/fuse/mount.rs
+++ b/project/slayerfs/src/fuse/mount.rs
@@ -20,7 +20,7 @@ use crate::vfs::fs::VFS;
 /// Build default mount options for SlayerFS.
 fn default_mount_options() -> MountOptions {
     let mut mo = MountOptions::default();
-    mo.fs_name("slayerfs");
+    mo.fs_name(std::env::var("SLAYERFS_FS_NAME").ok().map(|value| value.trim().to_string()).filter(|value| !value.is_empty()).unwrap_or_else(|| "slayerfs".to_string()));
     // Enable kernel-side permission checking (recommended for most filesystems)
     mo.default_permissions(true);
     // Allow other users to access the filesystem (required for multi-user scenarios and xfstests)

--- a/project/slayerfs/src/meta/client/mod.rs
+++ b/project/slayerfs/src/meta/client/mod.rs
@@ -1316,6 +1316,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         }
         self.inode_cache.add_child(parent, name, ino).await;
 
+        self.inode_cache.invalidate_inode(parent).await;
         self.invalidate_parent_path(parent).await;
 
         Ok(ino)
@@ -1332,6 +1333,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         debug!("MetaClient: rmdir completed, updating cache");
 
         self.inode_cache.remove_child(parent, name).await;
+        self.inode_cache.invalidate_inode(parent).await;
         self.invalidate_parent_path(parent).await;
 
         Ok(())
@@ -1364,6 +1366,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
         }
         self.inode_cache.add_child(parent, name, ino).await;
 
+        self.inode_cache.invalidate_inode(parent).await;
         self.invalidate_parent_path(parent).await;
 
         Ok(ino)
@@ -1395,6 +1398,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             .add_child(parent, name.to_string(), inode)
             .await;
 
+        self.inode_cache.invalidate_inode(parent).await;
         self.invalidate_parent_path(parent).await;
 
         Ok(attr)
@@ -1436,6 +1440,7 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             .add_child(parent, name.to_string(), ino)
             .await;
 
+        self.inode_cache.invalidate_inode(parent).await;
         self.invalidate_parent_path(parent).await;
 
         Ok((ino, attr))

--- a/project/slayerfs/src/meta/stores/database/mod.rs
+++ b/project/slayerfs/src/meta/stores/database/mod.rs
@@ -503,7 +503,7 @@ impl DatabaseMetaStore {
             .await
             .map_err(MetaError::Database)?;
 
-        // Update parent directory mtime
+        // Update parent directory mtime/ctime for the new entry
         let mut parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(parent_inode)
             .one(&txn)
             .await
@@ -511,6 +511,7 @@ impl DatabaseMetaStore {
             .unwrap()
             .into();
         parent_meta.modify_time = Set(now);
+        parent_meta.create_time = Set(now);
         parent_meta
             .update(&txn)
             .await
@@ -603,7 +604,7 @@ impl DatabaseMetaStore {
             .await
             .map_err(MetaError::Database)?;
 
-        // Update parent directory mtime
+        // Update parent directory mtime/ctime for the new entry
         let mut parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(parent_inode)
             .one(&txn)
             .await
@@ -611,6 +612,7 @@ impl DatabaseMetaStore {
             .unwrap()
             .into();
         parent_meta.modify_time = Set(now);
+        parent_meta.create_time = Set(now);
         parent_meta
             .update(&txn)
             .await
@@ -1370,14 +1372,17 @@ impl MetaStore for DatabaseMetaStore {
             .await
             .map_err(MetaError::Database)?;
 
-        // Update parent directory mtime
+        let now = Self::now_nanos();
+
+        // Update parent directory mtime/ctime for the removed entry
         let mut parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(parent)
             .one(&txn)
             .await
             .map_err(MetaError::Database)?
             .ok_or(MetaError::ParentNotFound(parent))?
             .into();
-        parent_meta.modify_time = Set(Utc::now().timestamp_nanos_opt().unwrap_or(0));
+        parent_meta.modify_time = Set(now);
+        parent_meta.create_time = Set(now);
         parent_meta
             .update(&txn)
             .await
@@ -1482,14 +1487,15 @@ impl MetaStore for DatabaseMetaStore {
         file_meta.create_time = Set(now);
         file_meta.update(&txn).await.map_err(MetaError::Database)?;
 
-        // Update parent directory mtime
+        // Update parent directory mtime/ctime for the removed entry
         let mut parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(parent)
             .one(&txn)
             .await
             .map_err(MetaError::Database)?
             .ok_or(MetaError::ParentNotFound(parent))?
             .into();
-        parent_meta.modify_time = Set(Utc::now().timestamp_nanos_opt().unwrap_or(0));
+        parent_meta.modify_time = Set(now);
+        parent_meta.create_time = Set(now);
         parent_meta
             .update(&txn)
             .await
@@ -1659,6 +1665,7 @@ impl MetaStore for DatabaseMetaStore {
 
         let mut parent_active: access_meta::ActiveModel = parent_dir.into();
         parent_active.modify_time = Set(now);
+        parent_active.create_time = Set(now);
         parent_active
             .update(&txn)
             .await
@@ -1737,6 +1744,7 @@ impl MetaStore for DatabaseMetaStore {
 
         let mut parent_active: access_meta::ActiveModel = parent_dir.into();
         parent_active.modify_time = Set(now);
+        parent_active.create_time = Set(now);
         parent_active
             .update(&txn)
             .await
@@ -1894,7 +1902,7 @@ impl MetaStore for DatabaseMetaStore {
         // For directories (nlink >= 2, no FileMeta), no additional updates needed
         // The ContentMeta update above is sufficient
 
-        // Update old parent mtime (not ctime, which should only change on metadata changes)
+        // Update parent directory mtime/ctime for the renamed entry
         let mut old_parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(old_parent)
             .one(&txn)
             .await
@@ -1902,12 +1910,12 @@ impl MetaStore for DatabaseMetaStore {
             .ok_or(MetaError::ParentNotFound(old_parent))?
             .into();
         old_parent_meta.modify_time = Set(now);
+        old_parent_meta.create_time = Set(now);
         old_parent_meta
             .update(&txn)
             .await
             .map_err(MetaError::Database)?;
 
-        // Update new parent mtime (if different)
         if old_parent != new_parent {
             let mut new_parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(new_parent)
                 .one(&txn)
@@ -1916,6 +1924,7 @@ impl MetaStore for DatabaseMetaStore {
                 .ok_or(MetaError::NotFound(new_parent))?
                 .into();
             new_parent_meta.modify_time = Set(now);
+            new_parent_meta.create_time = Set(now);
             new_parent_meta
                 .update(&txn)
                 .await
@@ -2078,7 +2087,7 @@ impl MetaStore for DatabaseMetaStore {
                 .map_err(MetaError::Database)?;
         }
 
-        // Update parent directories' mtime
+        // Update parent directories' mtime/ctime for the exchanged entries
         let mut old_parent_meta: access_meta::ActiveModel = AccessMeta::find_by_id(old_parent)
             .one(&txn)
             .await
@@ -2086,6 +2095,7 @@ impl MetaStore for DatabaseMetaStore {
             .ok_or(MetaError::ParentNotFound(old_parent))?
             .into();
         old_parent_meta.modify_time = Set(now);
+        old_parent_meta.create_time = Set(now);
         old_parent_meta
             .update(&txn)
             .await
@@ -2099,6 +2109,7 @@ impl MetaStore for DatabaseMetaStore {
                 .ok_or(MetaError::NotFound(new_parent))?
                 .into();
             new_parent_meta.modify_time = Set(now);
+            new_parent_meta.create_time = Set(now);
             new_parent_meta
                 .update(&txn)
                 .await

--- a/project/slayerfs/tests/scripts/xfstests_slayer.sh
+++ b/project/slayerfs/tests/scripts/xfstests_slayer.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 
 current_dir=$(dirname "$(realpath "$0")")
 workspace_dir=$(realpath "$current_dir/../../..")
-redis_config="$workspace_dir/slayerfs/slayerfs-sqlite.yml"
-backend_dir=/tmp/data
+default_config="$workspace_dir/slayerfs/slayerfs-sqlite.yml"
+config_path="${SLAYERFS_CONFIG:-$default_config}"
+backend_root=/tmp/slayerfs-xfstests
 mount_dir=/tmp/mount
-log_file=/tmp/slayerfs.log
+scratch_mount_dir=/tmp/test2/merged
+log_dir=/tmp/slayerfs-logs
 persistence_bin="$workspace_dir/target/release/examples/persistence_demo"
 xfstests_repo=https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
 xfstests_branch="${XFSTESTS_BRANCH:-v2023.12.10}"
@@ -20,25 +22,45 @@ if [[ ! -f "$persistence_bin" ]]; then
     exit 1
 fi
 
-sudo rm -rf "$backend_dir"
-while mount | grep -q "$mount_dir"; do
-    sudo umount -f "$mount_dir" || sleep 1
+if [[ ! -f "$config_path" ]]; then
+    echo "Cannot find slayerfs config: $config_path"
+    exit 1
+fi
+
+for dir in "$mount_dir" "$scratch_mount_dir"; do
+    while mount | awk '{print $3}' | grep -Fxq "$dir"; do
+        sudo umount -f "$dir" || sleep 1
+    done
+    sudo rm -rf "$dir"
 done
-sudo rm -rf "$mount_dir"
+sudo rm -rf "$backend_root"
 sudo rm -rf /tmp/xfstests-dev
-sudo mkdir -p "$backend_dir" "$mount_dir"
-sudo rm -f "$log_file"
+sudo mkdir -p "$backend_root" "$mount_dir" "$scratch_mount_dir" "$log_dir"
+sudo rm -f "$log_dir"/*.log /tmp/slayerfs.log
 
 export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update
-sudo apt-get install -y acl attr automake bc dbench dump e2fsprogs fio gawk \
-    gcc git indent libacl1-dev libaio-dev libcap-dev libgdbm-dev libtool \
-    libtool-bin liburing-dev libuuid1 lvm2 make psmisc python3 quota sed \
-    uuid-dev uuid-runtime xfsprogs sqlite3 \
-    fuse3
-sudo apt-get install -y exfatprogs f2fs-tools ocfs2-tools udftools xfsdump \
-    xfslibs-dev
-sudo apt-get install -y "linux-headers-$(uname -r)" || true
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y acl attr automake bc dbench dump e2fsprogs fio gawk \
+        gcc git indent libacl1-dev libaio-dev libcap-dev libgdbm-dev libtool \
+        libtool-bin liburing-dev libuuid1 lvm2 make psmisc python3 quota sed \
+        uuid-dev uuid-runtime xfsprogs sqlite3 \
+        fuse3
+    sudo apt-get install -y exfatprogs f2fs-tools ocfs2-tools udftools xfsdump \
+        xfslibs-dev
+    sudo apt-get install -y "linux-headers-$(uname -r)" || true
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y \
+        acl attr automake bc dump e2fsprogs fio gawk gcc git hostname indent \
+        libacl-devel libaio-devel libcap-devel gdbm-devel libtool \
+        liburing-devel lvm2 make psmisc python3 quota quota-devel sed \
+        sqlite xfsprogs xfsprogs-devel fuse3 util-linux-devel uuidd
+    sudo dnf install -y f2fs-tools xfsdump || true
+    sudo dnf install -y dbench exfatprogs ocfs2-tools udftools kernel-headers || true
+else
+    echo "Unsupported package manager: need apt-get or dnf"
+    exit 1
+fi
 
 # clone xfstests and install.
 cd /tmp/
@@ -48,45 +70,85 @@ make
 sudo make install
 
 # overwrite local config.
-cat >local.config  <<EOF
-export TEST_DEV=slayerfs
+cat >local.config <<CFG
+export TEST_DEV=slayerfs_test
 export TEST_DIR=$mount_dir
-#export SCRATCH_DEV=slayerfs
-#export SCRATCH_MNT=/tmp/test2/merged
+export SCRATCH_DEV=slayerfs_scratch
+export SCRATCH_MNT=$scratch_mount_dir
 export FSTYP=fuse
 export FUSE_SUBTYP=.slayerfs
 
-#Deleting the following command will result in an error: TEST_DEV=slayerfs is mounted but not a type fuse filesystem.
+# Deleting the following command will result in an error:
+# TEST_DEV=slayerfs is mounted but not a type fuse filesystem.
 export DF_PROG="df -T -P -a"
-EOF
+CFG
 
 # create fuse mount script for slayerfs.
-sudo tee /usr/sbin/mount.fuse.slayerfs >/dev/null <<EOF
+sudo tee /usr/sbin/mount.fuse.slayerfs >/dev/null <<EOF_HELPER
 #!/bin/bash
 set -euo pipefail
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\$PATH"
 
 ulimit -n 1048576
-CONFIG_PATH="$redis_config"
-LOG_FILE="$log_file"
+CONFIG_PATH="$config_path"
+BACKEND_ROOT="$backend_root"
+LOG_DIR="$log_dir"
 PERSISTENCE_BIN="$persistence_bin"
-
-BACKEND_DIR="$backend_dir"
-MOUNT_DIR="$mount_dir"
 SLAYERFS_RUST_LOG="$slayerfs_rust_log"
 SLAYERFS_FUSE_OP_LOG="$slayerfs_fuse_op_log"
+
+source_arg=""
+mount_target=""
+args=("\$@")
+index=0
+while [[ \$index -lt \${#args[@]} ]]; do
+  arg="\${args[\$index]}"
+  case "\$arg" in
+    -o|-O|-t)
+      index=\$((index + 2))
+      ;;
+    -*)
+      index=\$((index + 1))
+      ;;
+    *)
+      if [[ -z "\$source_arg" ]]; then
+        source_arg="\$arg"
+      elif [[ -z "\$mount_target" ]]; then
+        mount_target="\$arg"
+      fi
+      index=\$((index + 1))
+      ;;
+  esac
+done
+
+if [[ -z "\$mount_target" ]]; then
+  echo "mount.fuse.slayerfs: could not determine mount target from args: \$*" >&2
+  exit 1
+fi
+
+mount_key=\$(printf '%s' "\$mount_target" | sed 's#^/##; s#[/[:space:]]#-#g; s#[^A-Za-z0-9._-]#_#g')
+if [[ -z "\$mount_key" ]]; then
+  mount_key=root
+fi
+
+backend_dir="\$BACKEND_ROOT/\$mount_key"
+log_file="\$LOG_DIR/\$mount_key.log"
+mkdir -p "\$backend_dir" "\$mount_target" "\$LOG_DIR"
+
+export SLAYERFS_FS_NAME="\${source_arg:-slayerfs}"
 
 if [[ "\$SLAYERFS_FUSE_OP_LOG" == "1" ]]; then
   export RUST_LOG="\$SLAYERFS_RUST_LOG"
 fi
 
+echo "[\$(date --iso-8601=seconds)] mount source=\$source_arg target=\$mount_target fsname=\$SLAYERFS_FS_NAME backend=\$backend_dir" >>"\$log_file"
 "\$PERSISTENCE_BIN" \
   -c "\$CONFIG_PATH" \
-  -s "\$BACKEND_DIR" \
-  -m "\$MOUNT_DIR" >>"\$LOG_FILE" 2>&1 &
+  -s "\$backend_dir" \
+  -m "\$mount_target" >>"\$log_file" 2>&1 &
 sleep 1
-EOF
+EOF_HELPER
 sudo chmod +x /usr/sbin/mount.fuse.slayerfs
 
 echo "====> Start to run xfstests."

--- a/project/slayerfs/tests/scripts/xfstests_slayer.sh
+++ b/project/slayerfs/tests/scripts/xfstests_slayer.sh
@@ -50,13 +50,10 @@ if command -v apt-get >/dev/null 2>&1; then
         xfslibs-dev
     sudo apt-get install -y "linux-headers-$(uname -r)" || true
 elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y \
-        acl attr automake bc dump e2fsprogs fio gawk gcc git hostname indent \
-        libacl-devel libaio-devel libcap-devel gdbm-devel libtool \
-        liburing-devel lvm2 make psmisc python3 quota quota-devel sed \
-        sqlite xfsprogs xfsprogs-devel fuse3 util-linux-devel uuidd
-    sudo dnf install -y f2fs-tools xfsdump || true
-    sudo dnf install -y dbench exfatprogs ocfs2-tools udftools kernel-headers || true
+    dnf_install=(sudo dnf --setopt=skip_if_unavailable=True install -y)
+    "${dnf_install[@]}" acl attr automake bc dump e2fsprogs fio gawk gcc git hostname indent libacl-devel libaio-devel libcap-devel gdbm-devel libtool liburing-devel lvm2 make psmisc python3 quota quota-devel sed sqlite xfsprogs xfsprogs-devel fuse3 util-linux-devel uuidd
+    "${dnf_install[@]}" f2fs-tools xfsdump || true
+    "${dnf_install[@]}" dbench exfatprogs ocfs2-tools udftools kernel-headers || true
 else
     echo "Unsupported package manager: need apt-get or dnf"
     exit 1
@@ -157,9 +154,19 @@ sudo cp "$current_dir/xfstests_slayer.exclude" /tmp/xfstests-dev/
 
 # run tests.
 cd /tmp/xfstests-dev
-if [[ -n "${XFSTESTS_CASES:-}" ]]; then
+selected_cases=()
+if [[ $# -gt 0 ]]; then
+    selected_cases=("$@")
+elif [[ -n "${XFSTESTS_CASES:-}" ]]; then
     read -r -a selected_cases <<<"${XFSTESTS_CASES}"
-    sudo LC_ALL=C ./check -fuse "${selected_cases[@]}"
-else
-    sudo LC_ALL=C ./check -fuse -E xfstests_slayer.exclude
 fi
+
+check_args=(-fuse)
+if [[ ${#selected_cases[@]} -gt 0 ]]; then
+    check_args+=("${selected_cases[@]}")
+else
+    check_args+=(-E xfstests_slayer.exclude)
+fi
+
+echo "====> Running: ./check ${check_args[*]}"
+sudo LC_ALL=C ./check "${check_args[@]}"


### PR DESCRIPTION
- derive xfstests helper backend/log state from the actual mount target
- use distinct test/scratch device names in generated `local.config`
- make SlayerFS FUSE `fs_name` configurable through `SLAYERFS_FS_NAME`
- pass the requested mount source through the helper so test and scratch mounts show up as separate sources in xfstests

Tested by rebuilding `persistence_demo` and verifying that xfstests setup now exposes:
- `slayerfs_test /tmp/mount`
- `slayerfs_scratch /tmp/test2/merged`

Draft because focused-case selection and SQLite locking still need follow-up.

This builds on the existing SlayerFS xfstests setup and focuses specifically on unblocking `SCRATCH_DEV` by separating test and scratch mount identities.