### PR TITLE
slayerfs: preserve vfs metadata errors and fix etcd rename

### DIFF
--- a/project/slayerfs/src/meta/stores/etcd/mod.rs
+++ b/project/slayerfs/src/meta/stores/etcd/mod.rs
@@ -2008,7 +2008,7 @@ impl MetaStore for EtcdMetaStore {
                         .await?
                         .ok_or(MetaError::NotFound(entry_ino))?;
 
-                    if entry_info.nlink <= 1 {
+                    if !entry_info.is_file || entry_info.nlink <= 1 {
                         entry_info.parent_inode = new_parent;
                         entry_info.entry_name = new_name.clone();
                     } else {

--- a/project/slayerfs/src/meta/stores/etcd/tests.rs
+++ b/project/slayerfs/src/meta/stores/etcd/tests.rs
@@ -222,6 +222,28 @@ async fn test_hardlink_dentry_binding_cross_dir_move_rename() {
 #[serial]
 #[tokio::test]
 #[ignore]
+async fn test_directory_same_parent_rename_updates_lookup() {
+    let store = new_test_store().await;
+    let root = store.root_ino();
+
+    let parent = store.mkdir(root, "parent".to_string()).await.unwrap();
+    let dir_ino = store.mkdir(parent, "old_dir".to_string()).await.unwrap();
+
+    store
+        .rename(parent, "old_dir", parent, "new_dir".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(store.lookup(parent, "old_dir").await.unwrap(), None);
+    assert_eq!(
+        store.lookup(parent, "new_dir").await.unwrap(),
+        Some(dir_ino)
+    );
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
 async fn test_basic_read_lock() {
     let store = new_test_store().await;
     let session_id = Uuid::now_v7();

--- a/project/slayerfs/src/vfs/error.rs
+++ b/project/slayerfs/src/vfs/error.rs
@@ -312,3 +312,31 @@ impl From<VfsError> for std::io::Error {
         std::io::Error::new(kind, value.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PathHint, VfsError};
+    use crate::meta::store::MetaError;
+    use std::io::ErrorKind;
+
+    #[test]
+    fn from_meta_preserves_not_directory_semantics() {
+        let err = VfsError::from_meta(PathHint::some("/tmp/dst"), MetaError::NotDirectory(123));
+        assert!(matches!(err, VfsError::NotADirectory { .. }));
+
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn from_meta_preserves_directory_not_empty_semantics() {
+        let err = VfsError::from_meta(
+            PathHint::some("/tmp/dst"),
+            MetaError::DirectoryNotEmpty(123),
+        );
+        assert!(matches!(err, VfsError::DirectoryNotEmpty { .. }));
+
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::DirectoryNotEmpty);
+    }
+}

--- a/project/slayerfs/src/vfs/meta_ops.rs
+++ b/project/slayerfs/src/vfs/meta_ops.rs
@@ -1,7 +1,9 @@
 //! Thin wrappers around [`MetaLayer`] methods used by the VFS.
 //!
-//! Every method here converts `MetaError` → `VfsError` via `VfsError::from`,
-//! keeping the call sites in `fs.rs` free of repetitive boilerplate.
+//! Every method here converts `MetaError` → `VfsError` via `VfsError::from_meta`,
+//! preserving filesystem-specific error semantics instead of collapsing them
+//! into a generic wrapper that later turns into `EIO`.
+//! This keeps the call sites in `fs.rs` free of repetitive boilerplate.
 //! The three composite helpers (`meta_lookup_required`, `meta_stat_required`,
 //! `meta_lookup_path_required`) that were previously at the bottom of `fs.rs` live
 //! here as well, since they are purely metadata-layer concerns.
@@ -31,7 +33,7 @@ where
 
     /// Fetch attributes for `ino`, returning `None` when the inode is absent.
     pub(super) async fn meta_stat(&self, ino: i64) -> Result<Option<FileAttr>, VfsError> {
-        self.meta_layer().stat(ino).await.map_err(VfsError::from)
+        self.meta_layer().stat(ino).await.map_err(meta_err_to_vfs)
     }
 
     /// Fetch fresh (uncached) attributes for `ino`, returning `None` when absent.
@@ -39,7 +41,7 @@ where
         self.meta_layer()
             .stat_fresh(ino)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------
@@ -55,7 +57,7 @@ where
         self.meta_layer()
             .lookup(parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_lookup_required(
@@ -67,7 +69,7 @@ where
         self.meta_layer()
             .lookup(parent, name)
             .await
-            .map_err(VfsError::from)?
+            .map_err(meta_err_to_vfs)?
             .ok_or_else(|| VfsError::NotFound { path: hint })
     }
 
@@ -79,7 +81,7 @@ where
         self.meta_layer()
             .lookup_path(path)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------
@@ -106,14 +108,14 @@ where
         self.meta_layer()
             .mkdir(parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_rmdir(&self, parent: i64, name: &str) -> Result<(), VfsError> {
         self.meta_layer()
             .rmdir(parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_readdir(&self, ino: i64) -> Result<Vec<DirEntry>, VfsError> {
@@ -143,7 +145,7 @@ where
         self.meta_layer()
             .create_file(parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_link(
@@ -155,7 +157,7 @@ where
         self.meta_layer()
             .link(ino, parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_symlink(
@@ -167,14 +169,14 @@ where
         self.meta_layer()
             .symlink(parent, name, target)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_unlink(&self, parent: i64, name: &str) -> Result<(), VfsError> {
         self.meta_layer()
             .unlink(parent, name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------
@@ -191,7 +193,7 @@ where
         self.meta_layer()
             .rename(old_parent, old_name, new_parent, new_name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_rename_exchange(
@@ -204,7 +206,7 @@ where
         self.meta_layer()
             .rename_exchange(old_parent, old_name, new_parent, new_name)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------
@@ -220,14 +222,14 @@ where
         self.meta_layer()
             .set_attr(ino, req, flags)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_chmod(&self, ino: i64, new_mode: u32) -> Result<FileAttr, VfsError> {
         self.meta_layer()
             .chmod(ino, new_mode)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_chown(
@@ -239,7 +241,7 @@ where
         self.meta_layer()
             .chown(ino, uid, gid)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_truncate(
@@ -251,7 +253,7 @@ where
         self.meta_layer()
             .truncate(ino, size, chunk_size)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------
@@ -262,21 +264,21 @@ where
         self.meta_layer()
             .read_symlink(ino)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_get_dir_parent(&self, ino: i64) -> Result<Option<i64>, VfsError> {
         self.meta_layer()
             .get_dir_parent(ino)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     pub(super) async fn meta_get_paths(&self, ino: i64) -> Result<Vec<String>, VfsError> {
         self.meta_layer()
             .get_paths(ino)
             .await
-            .map_err(VfsError::from)
+            .map_err(meta_err_to_vfs)
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve metadata-layer error kinds in `project/slayerfs/src/vfs/meta_ops.rs` by switching direct `VfsError::from` conversions to semantic `VfsError::from_meta(...)` mapping
- add focused checks in `project/slayerfs/src/vfs/error.rs` so `NotDirectory` and `DirectoryNotEmpty` keep their expected filesystem errno instead of collapsing to fallback `EIO`
- fix the etcd backend rename path in `project/slayerfs/src/meta/stores/etcd/mod.rs` so directories do not get misclassified as hardlink-tracked entries during rename
- add an etcd regression test in `project/slayerfs/src/meta/stores/etcd/tests.rs` covering same-parent directory rename lookup updates

## Fixed behavior
- etcd directory rename no longer fails because directory `nlink = 2` is mistaken for a multi-hardlink file case
- metadata errors coming back from the meta layer are preserved as filesystem-specific VFS errors instead of being flattened too early

## Tests
- [x] `bash compose-xfstests/run_etcd_xfstests.sh --cases "generic/023"`
- [x] `bash compose-xfstests/run_etcd_xfstests.sh --cases "generic/035"`
