### PR TITLE
[slayerfs] fix(meta/cache): prevent creating incomplete cache from si…

### DIFF
--- a/project/slayerfs/benches/slayerfs_bench.rs
+++ b/project/slayerfs/benches/slayerfs_bench.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 use slayerfs::{
     BlockKey, BlockStore, CacheConfig, ChunkLayout, ClientOptions, Config, DatabaseConfig,
     DatabaseMetaStore, DatabaseType, EtcdMetaStore, LocalFsBackend, MetaClient, MetaStore,
-    MetaStoreFactory, ObjectBlockStore, ObjectClient, S3Backend, S3Config, VFS,
+    MetaStoreFactory, ObjectBlockStore, ObjectClient, RedisMetaStore, S3Backend, S3Config, VFS,
 };
 
 const MB: usize = 1024 * 1024;
@@ -116,6 +116,7 @@ enum BackendKind {
 #[derive(ValueEnum, Debug, Clone)]
 enum MetaBackendKind {
     Sqlx,
+    Redis,
     Etcd,
 }
 
@@ -151,6 +152,7 @@ struct S3BackendOpts {
 #[derive(Clone)]
 enum MetaBackend {
     Sqlx { url: String },
+    Redis { url: String },
     Etcd { urls: Vec<String> },
 }
 
@@ -198,6 +200,7 @@ impl BenchConfig {
 
         let meta_backend = match args.meta_backend {
             MetaBackendKind::Sqlx => MetaBackend::Sqlx { url: args.meta_url },
+            MetaBackendKind::Redis => MetaBackend::Redis { url: args.meta_url },
             MetaBackendKind::Etcd => {
                 let urls = args
                     .meta_etcd_urls
@@ -403,6 +406,24 @@ async fn create_meta_store(cfg: &BenchConfig) -> Result<Arc<dyn MetaStore>> {
             let handle = MetaStoreFactory::<DatabaseMetaStore>::create_from_config(config)
                 .await
                 .context("create sqlx meta store")?;
+            Ok(handle.store() as Arc<dyn MetaStore>)
+        }
+        MetaBackend::Redis { url } => {
+            let client = ClientOptions {
+                no_background_jobs: true,
+                ..ClientOptions::default()
+            };
+            let config = Config {
+                database: DatabaseConfig {
+                    db_config: DatabaseType::Redis { url: url.clone() },
+                },
+                cache: CacheConfig::default(),
+                client,
+                compact: Default::default(),
+            };
+            let handle = MetaStoreFactory::<RedisMetaStore>::create_from_config(config)
+                .await
+                .context("create redis meta store")?;
             Ok(handle.store() as Arc<dyn MetaStore>)
         }
         MetaBackend::Etcd { urls } => {

--- a/project/slayerfs/doc/bench.md
+++ b/project/slayerfs/doc/bench.md
@@ -34,7 +34,9 @@ cargo bench --bench slayerfs_bench
 | `SLAYERFS_BENCH_S3_REGION`（空）           | 可选，S3 区域                                     |
 | `SLAYERFS_BENCH_S3_ENDPOINT`（空）         | 可选，自定义兼容端点/MinIO                             |
 | `SLAYERFS_BENCH_S3_FORCE_PATH_STYLE`（未设置） | 可选布尔值，设为 `true` 可强制 path-style 访问            |
-| `SLAYERFS_BENCH_META_URL`（`sqlite::memory:`） | 元数据后端 URL，兼容 SQLite/PostgreSQL/Redis/Etcd 等 |
+| `SLAYERFS_BENCH_META_BACKEND`（sqlx）          | 元数据后端类型：`sqlx`、`redis` 或 `etcd`            |
+| `SLAYERFS_BENCH_META_URL`（`sqlite::memory:`） | 当后端为 `sqlx` / `redis` 时使用的元数据 URL         |
+| `SLAYERFS_BENCH_META_ETCD_URLS`（空）          | 当 `META_BACKEND=etcd` 时必须指定的 etcd endpoints   |
 
 SLAYERFS_BENCH_BIG_FILE_MB=256 \
 cargo bench --bench slayerfs_bench -- --warm-up-time 1 --profile-time 5
@@ -64,4 +66,3 @@ inferno-flamegraph out.folded > flame.svg
 ```
 
 wrap 模式会捕获进程的所有线程，并覆盖从启动到关闭的完整生命周期；如果服务器需要长时间常驻，可以在 wrap 命令中配合 `timeout` 或 `sleep` 控制采样窗口，避免生成过大的 `perf.data`。同样务必开启 `debug = true` 与 `RUSTFLAGS="-C force-frame-pointers=yes"`，以免火焰图里充满 `unknown`。最终得到的 `flame.svg` 可以与 `slayerfs_bench` 的结果互相印证，帮助你在真实 FUSE 负载下定位瓶颈如果缺少`inferno-flamegraph`请使用`cargo install inferno`，并确保`~/.cargo/bin`已经加入了PATH。
-

--- a/project/slayerfs/docker/README.md
+++ b/project/slayerfs/docker/README.md
@@ -21,6 +21,30 @@ bash compose-xfstests/run_redis_xfstests.sh --s3 --cases "generic/001"
 - `slayerfs.log`：SlayerFS 日志（按 run 独立保存）
 - `report.md`：汇总报告
 
+## 容器内跑 xfstests 压力工具 / perf
+
+入口：
+- `compose-xfstests/run_redis_perf.sh`
+- `compose-xfstests/run_etcd_perf.sh`
+
+```bash
+cd project/slayerfs/docker
+
+# 默认跑 dirstress + metaperf + looptest
+bash compose-xfstests/run_redis_perf.sh
+
+# 指定工具，并额外跑一次宿主机 slayerfs_bench
+bash compose-xfstests/run_etcd_perf.sh \
+  --tools "dirstress dirperf metaperf looptest" \
+  --slayerfs-bench
+```
+
+产物目录：`docker/compose-xfstests/artifacts/perf-run-*/`
+- `perf-summary.tsv`：每个压力工具的状态和耗时
+- `tools/*.log`：各工具原始输出
+- `slayerfs.log`：FUSE 挂载期 SlayerFS 日志
+- `slayerfs-bench/console.log`：可选的宿主机 Criterion bench 控制台输出
+
 ## 本地 KVM xfstests（旧路径）
 
 目录：`kvm-xfstests/`

--- a/project/slayerfs/docker/compose-xfstests/docker-compose.etcd-perf.yml
+++ b/project/slayerfs/docker/compose-xfstests/docker-compose.etcd-perf.yml
@@ -1,0 +1,154 @@
+services:
+  etcd:
+    image: quay.io/coreos/etcd:v3.6.0
+    container_name: etcd-slayerfs-perf
+    environment:
+      ETCDCTL_API: "3"
+    command: >
+      /usr/local/bin/etcd
+      --name etcd-single
+      --data-dir /etcd-data
+      --listen-client-urls http://0.0.0.0:2379
+      --advertise-client-urls http://etcd:2379
+      --listen-peer-urls http://0.0.0.0:2380
+      --initial-advertise-peer-urls http://etcd:2380
+      --initial-cluster etcd-single=http://etcd:2380
+      --initial-cluster-token etcd-cluster-token
+      --initial-cluster-state new
+      --auto-compaction-mode=revision
+      --auto-compaction-retention=5000
+      --quota-backend-bytes=17179869184
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    ports:
+      - "${ETCD_HOST_BIND:-127.0.0.1}:${ETCD_HOST_PORT:-12379}:2379"
+    networks:
+      - slayerfs-xfstests
+
+  etcd-maintenance:
+    image: slayerfs-etcd-maintenance:local
+    build:
+      context: ..
+      dockerfile: etcd-maintenance.Dockerfile
+    depends_on:
+      etcd:
+        condition: service_healthy
+    environment:
+      ETCDCTL_API: "3"
+      ETCDCTL_ENDPOINTS: http://etcd:2379
+      ETCD_COMPACT_RETENTION_REVISIONS: ${ETCD_COMPACT_RETENTION_REVISIONS:-5000}
+      ETCD_MAINTENANCE_INTERVAL_SECS: ${ETCD_MAINTENANCE_INTERVAL_SECS:-30}
+    restart: unless-stopped
+    networks:
+      - slayerfs-xfstests
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: rustfs-slayerfs-perf-etcd
+    expose:
+      - "9000"
+      - "9001"
+    ports:
+      - "${RUSTFS_HOST_BIND:-127.0.0.1}:${RUSTFS_S3_HOST_PORT:-19000}:9000"
+      - "${RUSTFS_HOST_BIND:-127.0.0.1}:${RUSTFS_CONSOLE_HOST_PORT:-19001}:9001"
+    environment:
+      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
+      RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
+      RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
+      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
+    command:
+      - --address
+      - :9000
+      - --console-enable
+      - --server-domains
+      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
+      - --access-key
+      - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
+      - --secret-key
+      - ${RUSTFS_SECRET_KEY:-rustfsadmin}
+      - /data
+    volumes:
+      - rustfs-data-perf-etcd:/data
+    networks:
+      - slayerfs-xfstests
+
+  rustfs-init:
+    image: amazon/aws-cli:latest
+    depends_on:
+      rustfs:
+        condition: service_started
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        mkdir -p /root/.aws
+        printf '[default]\ns3 =\n  addressing_style = path\n' > /root/.aws/config
+        timeout 180 sh -ec '
+          while true; do
+            aws --endpoint-url http://rustfs:9000 s3api create-bucket --bucket ${SLAYERFS_S3_BUCKET:-slayerfs-data} >/dev/null 2>&1 && exit 0
+            aws --endpoint-url http://rustfs:9000 s3api head-bucket --bucket ${SLAYERFS_S3_BUCKET:-slayerfs-data} >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+        '
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-rustfsadmin}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-rustfsadmin}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_EC2_METADATA_DISABLED: ${AWS_EC2_METADATA_DISABLED:-true}
+    networks:
+      - slayerfs-xfstests
+
+  perf:
+    image: slayerfs-xfstests-perf:local
+    build:
+      context: ../../..
+      dockerfile: slayerfs/docker/compose-xfstests/Dockerfile
+    depends_on:
+      etcd:
+        condition: service_healthy
+      etcd-maintenance:
+        condition: service_started
+      rustfs-init:
+        condition: service_completed_successfully
+    environment:
+      SLAYERFS_META_BACKEND: etcd
+      SLAYERFS_META_ETCD_URLS: http://etcd:2379
+      SLAYERFS_DATA_BACKEND: ${SLAYERFS_DATA_BACKEND:-local-fs}
+      SLAYERFS_DATA_DIR: /var/lib/slayerfs/data
+      SLAYERFS_S3_BUCKET: ${SLAYERFS_S3_BUCKET:-slayerfs-data}
+      SLAYERFS_S3_ENDPOINT: ${SLAYERFS_S3_ENDPOINT:-http://rustfs:9000}
+      SLAYERFS_S3_REGION: ${SLAYERFS_S3_REGION:-us-east-1}
+      SLAYERFS_S3_FORCE_PATH_STYLE: ${SLAYERFS_S3_FORCE_PATH_STYLE:-true}
+      SLAYERFS_CONFIG_PATH: /run/slayerfs/config.yaml
+      SLAYERFS_LOG_FILE: /artifacts/slayerfs.log
+      SLAYERFS_ARTIFACT_DIR: ${SLAYERFS_ARTIFACT_DIR:-}
+      SLAYERFS_ARTIFACT_ROOT: /artifacts
+      XFSTESTS_DIR: /opt/xfstests-dev
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-rustfsadmin}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-rustfsadmin}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_EC2_METADATA_DISABLED: ${AWS_EC2_METADATA_DISABLED:-true}
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/run_perf_in_container.sh"]
+    privileged: true
+    devices:
+      - /dev/fuse:/dev/fuse
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=unconfined
+    volumes:
+      - ./artifacts:/artifacts
+      - ./run_perf_in_container.sh:/usr/local/bin/run_perf_in_container.sh:ro
+      - slayerfs-state-perf-etcd:/var/lib/slayerfs
+    networks:
+      - slayerfs-xfstests
+
+networks:
+  slayerfs-xfstests:
+    driver: bridge
+
+volumes:
+  slayerfs-state-perf-etcd:
+  rustfs-data-perf-etcd:

--- a/project/slayerfs/docker/compose-xfstests/docker-compose.redis-perf.yml
+++ b/project/slayerfs/docker/compose-xfstests/docker-compose.redis-perf.yml
@@ -1,0 +1,123 @@
+services:
+  redis:
+    image: docker.io/library/redis:7.2-alpine
+    container_name: redis-slayerfs-perf
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    ports:
+      - "${REDIS_HOST_BIND:-127.0.0.1}:${REDIS_HOST_PORT:-16379}:6379"
+    networks:
+      - slayerfs-xfstests
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: rustfs-slayerfs-perf-redis
+    expose:
+      - "9000"
+      - "9001"
+    ports:
+      - "${RUSTFS_HOST_BIND:-127.0.0.1}:${RUSTFS_S3_HOST_PORT:-19000}:9000"
+      - "${RUSTFS_HOST_BIND:-127.0.0.1}:${RUSTFS_CONSOLE_HOST_PORT:-19001}:9001"
+    environment:
+      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfsadmin}
+      RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY:-rustfsadmin}
+      RUSTFS_CONSOLE_ENABLE: ${RUSTFS_CONSOLE_ENABLE:-true}
+      RUSTFS_SERVER_DOMAINS: ${RUSTFS_SERVER_DOMAINS:-rustfs}
+    command:
+      - --address
+      - :9000
+      - --console-enable
+      - --server-domains
+      - ${RUSTFS_SERVER_DOMAINS:-rustfs}
+      - --access-key
+      - ${RUSTFS_ACCESS_KEY:-rustfsadmin}
+      - --secret-key
+      - ${RUSTFS_SECRET_KEY:-rustfsadmin}
+      - /data
+    volumes:
+      - rustfs-data-perf-redis:/data
+    networks:
+      - slayerfs-xfstests
+
+  rustfs-init:
+    image: amazon/aws-cli:latest
+    depends_on:
+      rustfs:
+        condition: service_started
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        mkdir -p /root/.aws
+        printf '[default]\ns3 =\n  addressing_style = path\n' > /root/.aws/config
+        timeout 180 sh -ec '
+          while true; do
+            aws --endpoint-url http://rustfs:9000 s3api create-bucket --bucket ${SLAYERFS_S3_BUCKET:-slayerfs-data} >/dev/null 2>&1 && exit 0
+            aws --endpoint-url http://rustfs:9000 s3api head-bucket --bucket ${SLAYERFS_S3_BUCKET:-slayerfs-data} >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+        '
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-rustfsadmin}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-rustfsadmin}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_EC2_METADATA_DISABLED: ${AWS_EC2_METADATA_DISABLED:-true}
+    networks:
+      - slayerfs-xfstests
+
+  perf:
+    image: slayerfs-xfstests-perf:local
+    build:
+      context: ../../..
+      dockerfile: slayerfs/docker/compose-xfstests/Dockerfile
+    depends_on:
+      redis:
+        condition: service_healthy
+      rustfs-init:
+        condition: service_completed_successfully
+    environment:
+      SLAYERFS_META_BACKEND: redis
+      SLAYERFS_META_URL: redis://redis:6379/0
+      SLAYERFS_DATA_BACKEND: ${SLAYERFS_DATA_BACKEND:-local-fs}
+      SLAYERFS_DATA_DIR: /var/lib/slayerfs/data
+      SLAYERFS_S3_BUCKET: ${SLAYERFS_S3_BUCKET:-slayerfs-data}
+      SLAYERFS_S3_ENDPOINT: ${SLAYERFS_S3_ENDPOINT:-http://rustfs:9000}
+      SLAYERFS_S3_REGION: ${SLAYERFS_S3_REGION:-us-east-1}
+      SLAYERFS_S3_FORCE_PATH_STYLE: ${SLAYERFS_S3_FORCE_PATH_STYLE:-true}
+      SLAYERFS_CONFIG_PATH: /run/slayerfs/config.yaml
+      SLAYERFS_LOG_FILE: /artifacts/slayerfs.log
+      SLAYERFS_ARTIFACT_DIR: ${SLAYERFS_ARTIFACT_DIR:-}
+      SLAYERFS_ARTIFACT_ROOT: /artifacts
+      XFSTESTS_DIR: /opt/xfstests-dev
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-rustfsadmin}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-rustfsadmin}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-us-east-1}
+      AWS_EC2_METADATA_DISABLED: ${AWS_EC2_METADATA_DISABLED:-true}
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/run_perf_in_container.sh"]
+    privileged: true
+    devices:
+      - /dev/fuse:/dev/fuse
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor=unconfined
+    volumes:
+      - ./artifacts:/artifacts
+      - ./run_perf_in_container.sh:/usr/local/bin/run_perf_in_container.sh:ro
+      - slayerfs-state-perf-redis:/var/lib/slayerfs
+    networks:
+      - slayerfs-xfstests
+
+networks:
+  slayerfs-xfstests:
+    driver: bridge
+
+volumes:
+  slayerfs-state-perf-redis:
+  rustfs-data-perf-redis:

--- a/project/slayerfs/docker/compose-xfstests/run_etcd_perf.sh
+++ b/project/slayerfs/docker/compose-xfstests/run_etcd_perf.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(realpath "$SCRIPT_DIR/..")"
+PROJECT_DIR="$(realpath "$DOCKER_DIR/../..")"
+
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.etcd-perf.yml"
+ARTIFACTS_DIR="$SCRIPT_DIR/artifacts"
+
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+info() { log "INFO  $*"; }
+ok()   { log "OK    $*"; }
+err()  { log "ERROR $*" >&2; }
+
+usage() {
+    cat <<EOF
+用法: $(basename "$0") [选项]
+
+说明:
+  - 使用 docker compose 在容器内运行 xfstests 压力工具，元数据库为 etcd
+  - 可选附带运行宿主机上的 slayerfs_bench
+  - 测试产物输出到: $ARTIFACTS_DIR/perf-run-*
+
+选项:
+  --s3                       使用 rustfs 作为对象存储（SLAYERFS_DATA_BACKEND=s3）
+  --tools "<tool...>"        指定压力工具列表，默认: "dirstress metaperf looptest"
+  --slayerfs-bench           额外运行一次宿主机 cargo bench --bench slayerfs_bench
+  --bench-args "<args...>"   透传给 cargo bench 之后的 Criterion 参数
+  --keep                     结束后不执行 compose down（便于调试）
+  -h, --help                 显示帮助
+
+支持的 PERF_TOOLS:
+  dirstress dirperf metaperf looptest
+
+可通过环境变量覆盖各工具参数:
+  PERF_DIRSTRESS_ARGS PERF_DIRPERF_ARGS PERF_METAPERF_ARGS PERF_LOOPTEST_ARGS
+EOF
+    exit 0
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    if [[ -z "$value" ]]; then
+        err "$option 需要提供参数值"
+        exit 1
+    fi
+}
+
+KEEP=false
+USE_S3=false
+RUN_SLAYERFS_BENCH=false
+PERF_TOOLS_VALUE="dirstress metaperf looptest"
+BENCH_ARGS_VALUE=""
+
+while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+        --s3)
+            USE_S3=true
+            shift
+            ;;
+        --tools)
+            require_value "$1" "${2:-}"
+            PERF_TOOLS_VALUE="${2:-}"
+            shift 2
+            ;;
+        --slayerfs-bench)
+            RUN_SLAYERFS_BENCH=true
+            shift
+            ;;
+        --bench-args)
+            require_value "$1" "${2:-}"
+            BENCH_ARGS_VALUE="${2:-}"
+            shift 2
+            ;;
+        --keep)
+            KEEP=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            err "未知参数: $1"
+            usage
+            ;;
+    esac
+done
+
+mkdir -p "$ARTIFACTS_DIR"
+
+cleanup() {
+    if [[ "$KEEP" == true ]]; then
+        info "跳过 compose down (--keep)"
+        return 0
+    fi
+    docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+run_slayerfs_bench() {
+    local host_artifact_dir="$1"
+    local bench_artifact_dir="$host_artifact_dir/slayerfs-bench"
+    local benchmark_meta_urls="http://127.0.0.1:${ETCD_HOST_PORT:-12379}"
+    local -a bench_args=()
+
+    mkdir -p "$bench_artifact_dir"
+    if [[ -n "$BENCH_ARGS_VALUE" ]]; then
+        read -r -a bench_args <<<"$BENCH_ARGS_VALUE"
+    fi
+
+    info "运行宿主机 slayerfs_bench（etcd backend）"
+    (
+        cd "$PROJECT_DIR"
+        env \
+            RUST_LOG="${RUST_LOG:-warn}" \
+            SLAYERFS_BENCH_META_BACKEND=etcd \
+            SLAYERFS_BENCH_META_ETCD_URLS="$benchmark_meta_urls" \
+            SLAYERFS_BENCH_BACKEND="$([[ "$USE_S3" == true ]] && echo s3 || echo local)" \
+            SLAYERFS_BENCH_S3_BUCKET="${SLAYERFS_S3_BUCKET:-slayerfs-data}" \
+            SLAYERFS_BENCH_S3_REGION="${SLAYERFS_S3_REGION:-us-east-1}" \
+            SLAYERFS_BENCH_S3_ENDPOINT="http://127.0.0.1:${RUSTFS_S3_HOST_PORT:-19000}" \
+            SLAYERFS_BENCH_S3_FORCE_PATH_STYLE=true \
+            AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-rustfsadmin}" \
+            AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-rustfsadmin}" \
+            AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}" \
+            cargo bench -p slayerfs --bench slayerfs_bench -- "${bench_args[@]}"
+    ) 2>&1 | tee "$bench_artifact_dir/console.log"
+
+    if [[ -d "$PROJECT_DIR/target/criterion" ]]; then
+        rm -rf "$bench_artifact_dir/criterion"
+        cp -a "$PROJECT_DIR/target/criterion" "$bench_artifact_dir/criterion" || true
+    fi
+}
+
+info "构建宿主机 slayerfs release 二进制（供镜像 COPY）"
+bash "$DOCKER_DIR/build_slayerfs_host_binary.sh"
+
+info "构建 perf runner 镜像"
+docker compose -f "$COMPOSE_FILE" build perf
+
+ts="$(date +%s)-$RANDOM"
+host_artifact_dir="$ARTIFACTS_DIR/perf-run-${ts}"
+mkdir -p "$host_artifact_dir"
+
+export SLAYERFS_ARTIFACT_DIR="/artifacts/perf-run-${ts}"
+export SLAYERFS_S3_BUCKET="${SLAYERFS_S3_BUCKET:-slayerfs-data}"
+if [[ "$USE_S3" == true ]]; then
+    export SLAYERFS_DATA_BACKEND="s3"
+else
+    export SLAYERFS_DATA_BACKEND="local-fs"
+fi
+
+services=(etcd etcd-maintenance rustfs)
+info "启动依赖服务: ${services[*]}"
+docker compose -f "$COMPOSE_FILE" up -d "${services[@]}"
+
+info "初始化 rustfs bucket（一次性容器）"
+docker compose -f "$COMPOSE_FILE" run --rm rustfs-init
+
+info "运行容器内性能测试（退出码由 perf 容器决定）"
+set +e
+docker compose -f "$COMPOSE_FILE" run --rm \
+    -e PERF_TOOLS="$PERF_TOOLS_VALUE" \
+    -e PERF_DIRSTRESS_ARGS \
+    -e PERF_DIRPERF_ARGS \
+    -e PERF_METAPERF_ARGS \
+    -e PERF_LOOPTEST_ARGS \
+    -e PERF_DIRSTRESS_PROCS \
+    -e PERF_DIRSTRESS_FILES \
+    -e PERF_DIRSTRESS_PROCS_PER_DIR \
+    -e PERF_METAPERF_SECONDS \
+    -e PERF_METAPERF_FILE_SIZE \
+    -e PERF_METAPERF_OP_FILES \
+    -e PERF_METAPERF_BG_FILES \
+    -e PERF_LOOPTEST_ITERS \
+    -e PERF_LOOPTEST_BUF_SIZE \
+    perf
+container_status=$?
+set -e
+
+bench_status=0
+if [[ "$RUN_SLAYERFS_BENCH" == true ]]; then
+    set +e
+    run_slayerfs_bench "$host_artifact_dir"
+    bench_status=$?
+    set -e
+fi
+
+status=0
+if [[ "$container_status" -ne 0 ]]; then
+    status="$container_status"
+fi
+if [[ "$bench_status" -ne 0 ]]; then
+    status="$bench_status"
+fi
+
+ok "perf compose 运行结束 (container=$container_status, bench=$bench_status)"
+ok "产物目录: $host_artifact_dir"
+exit "$status"

--- a/project/slayerfs/docker/compose-xfstests/run_perf_in_container.sh
+++ b/project/slayerfs/docker/compose-xfstests/run_perf_in_container.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+info() { log "INFO  $*"; }
+ok()   { log "OK    $*"; }
+err()  { log "ERROR $*" >&2; }
+
+config_path="${SLAYERFS_CONFIG_PATH:-/run/slayerfs/config.yaml}"
+mount_dir="${SLAYERFS_MOUNT_POINT:-/mnt/slayerfs}"
+data_backend="${SLAYERFS_DATA_BACKEND:-local-fs}"
+data_dir="${SLAYERFS_DATA_DIR:-${SLAYERFS_HOME:-/var/lib/slayerfs}/data}"
+meta_backend="${SLAYERFS_META_BACKEND:-redis}"
+meta_url="${SLAYERFS_META_URL:-}"
+meta_etcd_urls="${SLAYERFS_META_ETCD_URLS:-http://etcd:2379}"
+sqlite_path="${SLAYERFS_SQLITE_PATH:-${SLAYERFS_HOME:-/var/lib/slayerfs}/metadata.db}"
+log_file="${SLAYERFS_LOG_FILE:-/artifacts/slayerfs.log}"
+xfstests_dir="${XFSTESTS_DIR:-/opt/xfstests-dev}"
+artifact_root="${SLAYERFS_ARTIFACT_ROOT:-/artifacts}"
+artifact_dir="${SLAYERFS_ARTIFACT_DIR:-}"
+perf_tools="${PERF_TOOLS:-dirstress metaperf looptest}"
+
+write_config() {
+    mkdir -p "$(dirname "$config_path")" "$mount_dir"
+    if [[ "$data_backend" == "local-fs" ]]; then
+        mkdir -p "$data_dir"
+    fi
+
+    {
+        echo "mount_point: $mount_dir"
+        echo
+        case "$data_backend" in
+            local-fs)
+                cat <<EOF
+data:
+  backend: local-fs
+  localfs:
+    data_dir: ${data_dir}
+EOF
+                ;;
+            s3)
+                bucket="${SLAYERFS_S3_BUCKET:-slayerfs-data}"
+                region="${SLAYERFS_S3_REGION:-us-east-1}"
+                endpoint="${SLAYERFS_S3_ENDPOINT:-http://rustfs:9000}"
+                force_path="${SLAYERFS_S3_FORCE_PATH_STYLE:-true}"
+                part_size="${SLAYERFS_S3_PART_SIZE:-16777216}"
+                max_conc="${SLAYERFS_S3_MAX_CONCURRENCY:-8}"
+                cat <<EOF
+data:
+  backend: s3
+  s3:
+    bucket: ${bucket}
+    region: ${region}
+    part_size: ${part_size}
+    max_concurrency: ${max_conc}
+    force_path_style: ${force_path}
+    endpoint: ${endpoint}
+EOF
+                ;;
+            *)
+                err "不支持的 SLAYERFS_DATA_BACKEND: $data_backend"
+                exit 1
+                ;;
+        esac
+        echo
+
+        case "$meta_backend" in
+            sqlite)
+                mkdir -p "$(dirname "$sqlite_path")"
+                local url="${meta_url:-sqlite://${sqlite_path}?mode=rwc}"
+                cat <<EOF
+meta:
+  backend: sqlx
+  sqlx:
+    url: "$url"
+EOF
+                ;;
+            redis)
+                if [[ -z "$meta_url" ]]; then
+                    err "SLAYERFS_META_URL 不能为空 (redis)"
+                    exit 1
+                fi
+                cat <<EOF
+meta:
+  backend: redis
+  redis:
+    url: "$meta_url"
+EOF
+                ;;
+            etcd)
+                cat <<EOF
+meta:
+  backend: etcd
+  etcd:
+    urls:
+EOF
+                local old_ifs="$IFS"
+                IFS=','
+                for url in $meta_etcd_urls; do
+                    echo "      - \"${url}\""
+                done
+                IFS="$old_ifs"
+                ;;
+            *)
+                err "不支持的 SLAYERFS_META_BACKEND: $meta_backend"
+                exit 1
+                ;;
+        esac
+
+        echo
+        cat <<EOF
+layout:
+  chunk_size: ${SLAYERFS_CHUNK_SIZE:-67108864}
+  block_size: ${SLAYERFS_BLOCK_SIZE:-4194304}
+EOF
+    } >"$config_path"
+}
+
+install_mount_helper() {
+    local helper="/usr/sbin/mount.fuse.slayerfs"
+    cat >"$helper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
+src="${1:-}"
+target="${2:-}"
+shift 2 || true
+
+config_path="${SLAYERFS_CONFIG_PATH:-/run/slayerfs/config.yaml}"
+log_file="${SLAYERFS_LOG_FILE:-/artifacts/slayerfs.log}"
+
+mkdir -p "$target" "$(dirname "$log_file")"
+
+/usr/local/bin/slayerfs mount --config "$config_path" "$target" >>"$log_file" 2>&1 &
+sleep "${SLAYERFS_MOUNT_WAIT_SECS:-1}"
+exit 0
+EOF
+    chmod +x "$helper"
+}
+
+prepare_artifacts() {
+    mkdir -p "$artifact_dir/results" "$artifact_dir/tools"
+    touch "$artifact_dir/perf.log" "$artifact_dir/perf-summary.tsv" >/dev/null 2>&1 || true
+    printf 'tool\tstatus\tseconds\tlog\n' >"$artifact_dir/perf-summary.tsv"
+}
+
+copy_artifacts() {
+    mkdir -p "$artifact_dir"
+    if [[ -f "$log_file" && "$log_file" != "$artifact_dir/slayerfs.log" ]]; then
+        cp -f "$log_file" "$artifact_dir/slayerfs.log" || true
+    fi
+    if [[ -f "$config_path" ]]; then
+        cp -f "$config_path" "$artifact_dir/backend.yml" || true
+    fi
+    chmod -R a+rwX "$artifact_dir" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+    while mount | grep -q " on $mount_dir "; do
+        fusermount3 -u "$mount_dir" >/dev/null 2>&1 \
+            || umount -f "$mount_dir" >/dev/null 2>&1 \
+            || umount -l "$mount_dir" >/dev/null 2>&1 \
+            || sleep 1
+    done
+    pkill -f "/usr/local/bin/slayerfs mount" >/dev/null 2>&1 || true
+}
+
+on_exit() {
+    local status=$?
+    copy_artifacts || true
+    cleanup || true
+    trap - EXIT
+    exit "$status"
+}
+
+require_tool_bin() {
+    local bin="$1"
+    if [[ ! -x "$bin" ]]; then
+        err "找不到可执行工具: $bin"
+        exit 1
+    fi
+}
+
+mount_slayerfs() {
+    mkdir -p "$mount_dir"
+    if mountpoint -q "$mount_dir"; then
+        cleanup
+    fi
+
+    info "挂载 SlayerFS: $mount_dir"
+    mount -t fuse.slayerfs slayerfs "$mount_dir"
+
+    local i=0
+    for ((i = 0; i < 15; i++)); do
+        if mountpoint -q "$mount_dir"; then
+            ok "SlayerFS 已挂载"
+            return 0
+        fi
+        sleep 1
+    done
+
+    err "SlayerFS 挂载失败: $mount_dir"
+    exit 1
+}
+
+run_logged_tool() {
+    local tool="$1"
+    shift
+    local log_path="$artifact_dir/tools/${tool}.log"
+    local start end elapsed status
+
+    start="$(date +%s)"
+    info "运行压力工具: $tool"
+    set +e
+    "$@" 2>&1 | tee "$log_path"
+    status="${PIPESTATUS[0]}"
+    set -e
+    end="$(date +%s)"
+    elapsed="$((end - start))"
+
+    if [[ "$status" -eq 0 ]]; then
+        ok "压力工具完成: $tool (${elapsed}s)"
+        printf '%s\tpass\t%s\t%s\n' "$tool" "$elapsed" "$log_path" >>"$artifact_dir/perf-summary.tsv"
+    else
+        err "压力工具失败: $tool (exit=$status, ${elapsed}s)"
+        printf '%s\tfail(%s)\t%s\t%s\n' "$tool" "$status" "$elapsed" "$log_path" >>"$artifact_dir/perf-summary.tsv"
+    fi
+
+    return "$status"
+}
+
+run_dirstress() {
+    local bin="$xfstests_dir/src/dirstress"
+    local work_dir="$mount_dir/.perf-dirstress"
+    local -a args=()
+
+    require_tool_bin "$bin"
+    rm -rf "$work_dir"
+    mkdir -p "$work_dir"
+
+    if [[ -n "${PERF_DIRSTRESS_ARGS:-}" ]]; then
+        read -r -a args <<<"${PERF_DIRSTRESS_ARGS}"
+    else
+        args=(
+            -d "$work_dir"
+            -p "${PERF_DIRSTRESS_PROCS:-4}"
+            -f "${PERF_DIRSTRESS_FILES:-200}"
+            -n "${PERF_DIRSTRESS_PROCS_PER_DIR:-2}"
+            -s "${PERF_DIRSTRESS_SEED:-1}"
+        )
+    fi
+
+    run_logged_tool dirstress "$bin" "${args[@]}"
+}
+
+run_dirperf() {
+    local bin="$xfstests_dir/src/dirperf"
+    local work_dir="$mount_dir/.perf-dirperf"
+    local -a args=()
+
+    require_tool_bin "$bin"
+    rm -rf "$work_dir"
+    mkdir -p "$work_dir"
+
+    if [[ -n "${PERF_DIRPERF_ARGS:-}" ]]; then
+        read -r -a args <<<"${PERF_DIRPERF_ARGS}"
+    else
+        args=(
+            -d "$work_dir"
+            -a "${PERF_DIRPERF_ADDSTEP:-100}"
+            -f "${PERF_DIRPERF_FIRST:-100}"
+            -l "${PERF_DIRPERF_LAST:-1000}"
+            -c "${PERF_DIRPERF_NAME_LEN:-16}"
+            -n "${PERF_DIRPERF_DIRS:-2}"
+            -s "${PERF_DIRPERF_STATS:-5}"
+        )
+    fi
+
+    run_logged_tool dirperf "$bin" "${args[@]}"
+}
+
+run_metaperf() {
+    local bin="$xfstests_dir/src/metaperf"
+    local work_dir="$mount_dir/.perf-metaperf"
+    local -a args=()
+
+    require_tool_bin "$bin"
+    rm -rf "$work_dir"
+    mkdir -p "$work_dir"
+
+    if [[ -n "${PERF_METAPERF_ARGS:-}" ]]; then
+        read -r -a args <<<"${PERF_METAPERF_ARGS}"
+    else
+        args=(
+            -d "$work_dir"
+            -t "${PERF_METAPERF_SECONDS:-30}"
+            -s "${PERF_METAPERF_FILE_SIZE:-4096}"
+            -l "${PERF_METAPERF_NAME_LEN:-16}"
+            -L "${PERF_METAPERF_BG_NAME_LEN:-16}"
+            -n "${PERF_METAPERF_OP_FILES:-200}"
+            -N "${PERF_METAPERF_BG_FILES:-2000}"
+            create
+            open
+            stat
+            readdir
+            rename
+        )
+    fi
+
+    run_logged_tool metaperf "$bin" "${args[@]}"
+}
+
+run_looptest() {
+    local bin="$xfstests_dir/src/looptest"
+    local work_dir="$mount_dir/.perf-looptest"
+    local loop_file="$work_dir/looptest.dat"
+    local -a args=()
+
+    require_tool_bin "$bin"
+    rm -rf "$work_dir"
+    mkdir -p "$work_dir"
+
+    if [[ -n "${PERF_LOOPTEST_ARGS:-}" ]]; then
+        read -r -a args <<<"${PERF_LOOPTEST_ARGS}"
+    else
+        args=(
+            -i "${PERF_LOOPTEST_ITERS:-200}"
+            -o
+            -r
+            -w
+            -t
+            -f
+            -s
+            -b "${PERF_LOOPTEST_BUF_SIZE:-1048576}"
+            "$loop_file"
+        )
+    fi
+
+    run_logged_tool looptest "$bin" "${args[@]}"
+}
+
+run_perf_suite() {
+    local -a tools=()
+    local status=0
+    local tool=""
+
+    read -r -a tools <<<"$perf_tools"
+    if [[ "${#tools[@]}" -eq 0 ]]; then
+        err "PERF_TOOLS 不能为空"
+        exit 1
+    fi
+
+    for tool in "${tools[@]}"; do
+        case "$tool" in
+            dirstress)
+                run_dirstress || status=1
+                ;;
+            dirperf)
+                run_dirperf || status=1
+                ;;
+            metaperf)
+                run_metaperf || status=1
+                ;;
+            looptest)
+                run_looptest || status=1
+                ;;
+            *)
+                err "不支持的 PERF_TOOLS 项: $tool"
+                status=1
+                ;;
+        esac
+    done
+
+    return "$status"
+}
+
+main() {
+    if [[ -z "$artifact_dir" ]]; then
+        local ts
+        ts="$(date +%s)-$RANDOM"
+        artifact_dir="${artifact_root%/}/perf-run-${ts}"
+    fi
+
+    mkdir -p "$artifact_dir"
+    chmod a+rwx "$artifact_dir" >/dev/null 2>&1 || true
+    log_file="$artifact_dir/slayerfs.log"
+    export SLAYERFS_LOG_FILE="$log_file"
+
+    trap on_exit EXIT INT TERM
+
+    info "写入 SlayerFS 配置: $config_path"
+    write_config
+
+    info "安装 mount helper: /usr/sbin/mount.fuse.slayerfs"
+    install_mount_helper
+
+    info "准备产物目录: $artifact_dir"
+    prepare_artifacts
+
+    mount_slayerfs
+
+    info "开始性能测试: tools=$perf_tools"
+    set +e
+    run_perf_suite
+    status=$?
+    set -e
+
+    if [[ "$status" -eq 0 ]]; then
+        ok "性能测试全部完成"
+    else
+        err "性能测试存在失败项 (exit=$status)"
+    fi
+
+    return "$status"
+}
+
+main "$@"

--- a/project/slayerfs/docker/compose-xfstests/run_redis_perf.sh
+++ b/project/slayerfs/docker/compose-xfstests/run_redis_perf.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$(realpath "$SCRIPT_DIR/..")"
+PROJECT_DIR="$(realpath "$DOCKER_DIR/../..")"
+
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.redis-perf.yml"
+ARTIFACTS_DIR="$SCRIPT_DIR/artifacts"
+
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+info() { log "INFO  $*"; }
+ok()   { log "OK    $*"; }
+err()  { log "ERROR $*" >&2; }
+
+usage() {
+    cat <<EOF
+用法: $(basename "$0") [选项]
+
+说明:
+  - 使用 docker compose 在容器内运行 xfstests 压力工具，元数据库为 redis
+  - 可选附带运行宿主机上的 slayerfs_bench
+  - 测试产物输出到: $ARTIFACTS_DIR/perf-run-*
+
+选项:
+  --s3                       使用 rustfs 作为对象存储（SLAYERFS_DATA_BACKEND=s3）
+  --tools "<tool...>"        指定压力工具列表，默认: "dirstress metaperf looptest"
+  --slayerfs-bench           额外运行一次宿主机 cargo bench --bench slayerfs_bench
+  --bench-args "<args...>"   透传给 cargo bench 之后的 Criterion 参数
+  --keep                     结束后不执行 compose down（便于调试）
+  -h, --help                 显示帮助
+
+支持的 PERF_TOOLS:
+  dirstress dirperf metaperf looptest
+
+可通过环境变量覆盖各工具参数:
+  PERF_DIRSTRESS_ARGS PERF_DIRPERF_ARGS PERF_METAPERF_ARGS PERF_LOOPTEST_ARGS
+EOF
+    exit 0
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    if [[ -z "$value" ]]; then
+        err "$option 需要提供参数值"
+        exit 1
+    fi
+}
+
+KEEP=false
+USE_S3=false
+RUN_SLAYERFS_BENCH=false
+PERF_TOOLS_VALUE="dirstress metaperf looptest"
+BENCH_ARGS_VALUE=""
+
+while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+        --s3)
+            USE_S3=true
+            shift
+            ;;
+        --tools)
+            require_value "$1" "${2:-}"
+            PERF_TOOLS_VALUE="${2:-}"
+            shift 2
+            ;;
+        --slayerfs-bench)
+            RUN_SLAYERFS_BENCH=true
+            shift
+            ;;
+        --bench-args)
+            require_value "$1" "${2:-}"
+            BENCH_ARGS_VALUE="${2:-}"
+            shift 2
+            ;;
+        --keep)
+            KEEP=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            err "未知参数: $1"
+            usage
+            ;;
+    esac
+done
+
+mkdir -p "$ARTIFACTS_DIR"
+
+cleanup() {
+    if [[ "$KEEP" == true ]]; then
+        info "跳过 compose down (--keep)"
+        return 0
+    fi
+    docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+run_slayerfs_bench() {
+    local host_artifact_dir="$1"
+    local bench_artifact_dir="$host_artifact_dir/slayerfs-bench"
+    local benchmark_meta_url="redis://127.0.0.1:${REDIS_HOST_PORT:-16379}/0"
+    local -a bench_args=()
+
+    mkdir -p "$bench_artifact_dir"
+    if [[ -n "$BENCH_ARGS_VALUE" ]]; then
+        read -r -a bench_args <<<"$BENCH_ARGS_VALUE"
+    fi
+
+    info "运行宿主机 slayerfs_bench（redis backend）"
+    (
+        cd "$PROJECT_DIR"
+        env \
+            RUST_LOG="${RUST_LOG:-warn}" \
+            SLAYERFS_BENCH_META_BACKEND=redis \
+            SLAYERFS_BENCH_META_URL="$benchmark_meta_url" \
+            SLAYERFS_BENCH_BACKEND="$([[ "$USE_S3" == true ]] && echo s3 || echo local)" \
+            SLAYERFS_BENCH_S3_BUCKET="${SLAYERFS_S3_BUCKET:-slayerfs-data}" \
+            SLAYERFS_BENCH_S3_REGION="${SLAYERFS_S3_REGION:-us-east-1}" \
+            SLAYERFS_BENCH_S3_ENDPOINT="http://127.0.0.1:${RUSTFS_S3_HOST_PORT:-19000}" \
+            SLAYERFS_BENCH_S3_FORCE_PATH_STYLE=true \
+            AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-rustfsadmin}" \
+            AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-rustfsadmin}" \
+            AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}" \
+            cargo bench -p slayerfs --bench slayerfs_bench -- "${bench_args[@]}"
+    ) 2>&1 | tee "$bench_artifact_dir/console.log"
+
+    if [[ -d "$PROJECT_DIR/target/criterion" ]]; then
+        rm -rf "$bench_artifact_dir/criterion"
+        cp -a "$PROJECT_DIR/target/criterion" "$bench_artifact_dir/criterion" || true
+    fi
+}
+
+info "构建宿主机 slayerfs release 二进制（供镜像 COPY）"
+bash "$DOCKER_DIR/build_slayerfs_host_binary.sh"
+
+info "构建 perf runner 镜像"
+docker compose -f "$COMPOSE_FILE" build perf
+
+ts="$(date +%s)-$RANDOM"
+host_artifact_dir="$ARTIFACTS_DIR/perf-run-${ts}"
+mkdir -p "$host_artifact_dir"
+
+export SLAYERFS_ARTIFACT_DIR="/artifacts/perf-run-${ts}"
+export SLAYERFS_S3_BUCKET="${SLAYERFS_S3_BUCKET:-slayerfs-data}"
+if [[ "$USE_S3" == true ]]; then
+    export SLAYERFS_DATA_BACKEND="s3"
+else
+    export SLAYERFS_DATA_BACKEND="local-fs"
+fi
+
+services=(redis rustfs)
+info "启动依赖服务: ${services[*]}"
+docker compose -f "$COMPOSE_FILE" up -d "${services[@]}"
+
+info "初始化 rustfs bucket（一次性容器）"
+docker compose -f "$COMPOSE_FILE" run --rm rustfs-init
+
+info "运行容器内性能测试（退出码由 perf 容器决定）"
+set +e
+docker compose -f "$COMPOSE_FILE" run --rm \
+    -e PERF_TOOLS="$PERF_TOOLS_VALUE" \
+    -e PERF_DIRSTRESS_ARGS \
+    -e PERF_DIRPERF_ARGS \
+    -e PERF_METAPERF_ARGS \
+    -e PERF_LOOPTEST_ARGS \
+    -e PERF_DIRSTRESS_PROCS \
+    -e PERF_DIRSTRESS_FILES \
+    -e PERF_DIRSTRESS_PROCS_PER_DIR \
+    -e PERF_METAPERF_SECONDS \
+    -e PERF_METAPERF_FILE_SIZE \
+    -e PERF_METAPERF_OP_FILES \
+    -e PERF_METAPERF_BG_FILES \
+    -e PERF_LOOPTEST_ITERS \
+    -e PERF_LOOPTEST_BUF_SIZE \
+    perf
+container_status=$?
+set -e
+
+bench_status=0
+if [[ "$RUN_SLAYERFS_BENCH" == true ]]; then
+    set +e
+    run_slayerfs_bench "$host_artifact_dir"
+    bench_status=$?
+    set -e
+fi
+
+status=0
+if [[ "$container_status" -ne 0 ]]; then
+    status="$container_status"
+fi
+if [[ "$bench_status" -ne 0 ]]; then
+    status="$bench_status"
+fi
+
+ok "perf compose 运行结束 (container=$container_status, bench=$bench_status)"
+ok "产物目录: $host_artifact_dir"
+exit "$status"

--- a/project/slayerfs/docker/run_perf_etcd.sh
+++ b/project/slayerfs/docker/run_perf_etcd.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/compose-xfstests/run_etcd_perf.sh" "$@"

--- a/project/slayerfs/docker/run_perf_redis.sh
+++ b/project/slayerfs/docker/run_perf_redis.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/compose-xfstests/run_redis_perf.sh" "$@"

--- a/project/slayerfs/src/fuse/mod.rs
+++ b/project/slayerfs/src/fuse/mod.rs
@@ -25,10 +25,11 @@ use bytes::Bytes;
 use rfuse3::Errno;
 use rfuse3::Result as FuseResult;
 use rfuse3::raw::Request;
+use rfuse3::raw::flags::FUSE_WRITE_CACHE;
 use rfuse3::raw::reply::{
-    DirectoryEntry, DirectoryEntryPlus, ReplyAttr, ReplyCreated, ReplyData, ReplyDirectory,
-    ReplyDirectoryPlus, ReplyEntry, ReplyInit, ReplyLock, ReplyOpen, ReplyStatFs, ReplyWrite,
-    ReplyXAttr,
+    DirectoryEntry, DirectoryEntryPlus, ReplyAttr, ReplyCopyFileRange, ReplyCreated, ReplyData,
+    ReplyDirectory, ReplyDirectoryPlus, ReplyEntry, ReplyInit, ReplyLock, ReplyOpen, ReplyStatFs,
+    ReplyWrite, ReplyXAttr,
 };
 use std::ffi::{OsStr, OsString};
 use std::time::Duration;
@@ -173,6 +174,15 @@ where
         }
     }
 }
+
+fn fuse_lock_end_to_exclusive(end: u64) -> u64 {
+    end.saturating_add(1)
+}
+
+fn exclusive_lock_end_to_fuse(end: u64) -> u64 {
+    end.saturating_sub(1)
+}
+
 #[allow(refining_impl_trait_reachable)]
 impl<S, M> Filesystem for VFS<S, M>
 where
@@ -229,7 +239,10 @@ where
             .await
             .map_err(Into::<Errno>::into)?;
 
-        Ok(ReplyOpen { fh, flags })
+        // ReplyOpen.flags carries FUSE FOPEN_* bits, not the caller's O_* flags.
+        // Passing O_RDWR/O_WRONLY through here accidentally enables KEEP_CACHE or
+        // DIRECT_IO and can break buffered mmap/truncate visibility semantics.
+        Ok(ReplyOpen { fh, flags: 0 })
     }
 
     // Open directory: create handle for caching
@@ -311,11 +324,25 @@ where
         fh: u64,
         offset: u64,
         data: &[u8],
-        _write_flags: u32,
+        write_flags: u32,
         _flags: u32,
     ) -> FuseResult<ReplyWrite> {
-        debug!(ino, fh, offset, size = data.len(), "fuse.write");
-        let n = if fh != 0 {
+        debug!(
+            ino,
+            fh,
+            offset,
+            size = data.len(),
+            write_flags,
+            "fuse.write"
+        );
+        let n = if write_flags & FUSE_WRITE_CACHE != 0 {
+            // With writeback cache, Linux may send delayed page-cache writes with
+            // a guessed file handle. Route them through inode-based write so they
+            // share inode serialization even if the guessed fh is stale.
+            self.write_ino(ino as i64, offset, data)
+                .await
+                .map_err(Into::<Errno>::into)? as u32
+        } else if fh != 0 {
             self.write(fh, offset, data)
                 .await
                 .map_err(Into::<Errno>::into)? as u32
@@ -393,10 +420,17 @@ where
             .map_err(Into::<Errno>::into)?;
 
         let attr = vfs_to_fuse_attr(&vattr, &req);
-        Ok(ReplyAttr {
-            ttl: Duration::from_secs(1),
-            attr,
-        })
+
+        // When a truncate (size change) is involved, use TTL=0 so the kernel
+        // does not cache a potentially stale size.  A wrong cached size can
+        // cause the kernel to call truncate_pagecache with the wrong boundary,
+        // invalidating (or keeping) wrong pages in the writeback-cache path.
+        let ttl = if meta_req.size.is_some() {
+            Duration::ZERO
+        } else {
+            Duration::from_secs(1)
+        };
+        Ok(ReplyAttr { ttl, attr })
     }
 
     // Call VFS to list directory and stream DirectoryEntry items (with error/offset handling)
@@ -1099,6 +1133,36 @@ where
         self.fsync(fh, datasync).await.map_err(Errno::from)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn copy_file_range(
+        &self,
+        _req: Request,
+        inode: u64,
+        fh_in: u64,
+        off_in: u64,
+        inode_out: u64,
+        fh_out: u64,
+        off_out: u64,
+        length: u64,
+        flags: u64,
+    ) -> FuseResult<ReplyCopyFileRange> {
+        debug!(
+            inode,
+            fh_in, off_in, inode_out, fh_out, off_out, length, flags, "fuse.copy_file_range"
+        );
+
+        if flags != 0 {
+            return Err(libc::EINVAL.into());
+        }
+
+        let copied = self
+            .copy_file_range(fh_in, off_in, fh_out, off_out, length)
+            .await
+            .map_err(Into::<Errno>::into)? as u64;
+
+        Ok(ReplyCopyFileRange { copied })
+    }
+
     async fn setxattr(
         &self,
         _req: Request,
@@ -1250,7 +1314,10 @@ where
         let query = FileLockQuery {
             owner: lock_owner as i64,
             lock_type: fl_type,
-            range: FileLockRange { start, end },
+            range: FileLockRange {
+                start,
+                end: fuse_lock_end_to_exclusive(end),
+            },
         };
 
         match self.get_plock_ino(inode as i64, &query).await {
@@ -1264,7 +1331,7 @@ where
                 Ok(ReplyLock {
                     r#type: fuse_type as u32,
                     start: info.range.start,
-                    end: info.range.end,
+                    end: exclusive_lock_end_to_fuse(info.range.end),
                     pid: info.pid,
                 })
             }
@@ -1297,7 +1364,10 @@ where
             _ => return Err(libc::EINVAL.into()),
         };
 
-        let range = FileLockRange { start, end };
+        let range = FileLockRange {
+            start,
+            end: fuse_lock_end_to_exclusive(end),
+        };
 
         // Forward block parameter to MetaStore; backend may choose to block or return conflicts
         match self

--- a/project/slayerfs/src/meta/client/cache.rs
+++ b/project/slayerfs/src/meta/client/cache.rs
@@ -312,20 +312,46 @@ impl InodeCache {
 
     pub(crate) async fn append_slice(&self, inode: i64, chunk_index: u64, desc: SliceDesc) {
         if let Some(node) = self.ttl_manager.get(&inode).await {
-            node.slices
-                .entry(chunk_index)
-                .and_modify(|slices| slices.push(desc))
-                .or_insert_with(|| vec![desc]);
+            // Only append to an EXISTING cached slice list that was populated
+            // from a full backend read (via get_slices → cache_slices_if_absent).
+            // Do NOT create a new entry from a single slice — that produces a
+            // partial list that get_slices would trust as authoritative, causing
+            // it to miss slices that exist in the backing store.  This matters
+            // after truncate: invalidate_inode clears the cache, insert_node
+            // recreates it with an empty slices map, and post-truncate writes
+            // would otherwise seed a partial entry that shadows the full list.
+            if let Some(mut slices) = node.slices.get_mut(&chunk_index) {
+                slices.push(desc);
+            }
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn replace_slices(&self, inode: i64, chunk_index: u64, desc: &[SliceDesc]) {
         if let Some(node) = self.ttl_manager.get(&inode).await {
-            node.slices
-                .entry(chunk_index)
-                .and_modify(|slices| *slices = desc.to_owned())
-                .or_insert_with(|| desc.to_owned());
+            // Same rationale as append_slice: only update an existing entry.
+            if let Some(mut slices) = node.slices.get_mut(&chunk_index) {
+                *slices = desc.to_owned();
+            }
         }
+    }
+
+    pub(crate) async fn cache_slices_if_absent(
+        &self,
+        inode: i64,
+        chunk_index: u64,
+        desc: &[SliceDesc],
+    ) -> Option<Vec<SliceDesc>> {
+        let node = self.ttl_manager.get(&inode).await?;
+        let entry = node.slices.entry(chunk_index);
+        Some(match entry {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let cached = desc.to_owned();
+                entry.insert(cached.clone());
+                cached
+            }
+        })
     }
 
     pub(crate) async fn invalidate_slices(&self, inode: i64, chunk_index: u64) {

--- a/project/slayerfs/src/meta/client/mod.rs
+++ b/project/slayerfs/src/meta/client/mod.rs
@@ -1979,11 +1979,13 @@ impl<T: MetaStore + ?Sized + 'static> MetaLayer for MetaClient<T> {
             .get_slices(chunk_id)
             .instrument(tracing::trace_span!("get_slices.store", chunk_id))
             .await?;
-        self.inode_cache
-            .replace_slices(inode, chunk_index, &slices)
-            .await;
-        tracing::Span::current().record("slice_count", slices.len());
-        Ok(slices)
+        let cached = self
+            .inode_cache
+            .cache_slices_if_absent(inode, chunk_index, &slices)
+            .await
+            .unwrap_or(slices);
+        tracing::Span::current().record("slice_count", cached.len());
+        Ok(cached)
     }
 
     #[tracing::instrument(
@@ -2110,6 +2112,7 @@ mod tests {
             },
             cache: CacheConfig::default(),
             client: ClientOptions::default(),
+            compact: CompactConfig::default(),
         };
 
         let store = Arc::new(DatabaseMetaStore::from_config(config).await.unwrap());

--- a/project/slayerfs/src/meta/stores/etcd/mod.rs
+++ b/project/slayerfs/src/meta/stores/etcd/mod.rs
@@ -2008,7 +2008,7 @@ impl MetaStore for EtcdMetaStore {
                         .await?
                         .ok_or(MetaError::NotFound(entry_ino))?;
 
-                    if !entry_info.is_file || entry_info.nlink <= 1 {
+                    if entry_info.nlink <= 1 {
                         entry_info.parent_inode = new_parent;
                         entry_info.entry_name = new_name.clone();
                     } else {

--- a/project/slayerfs/src/meta/stores/etcd/tests.rs
+++ b/project/slayerfs/src/meta/stores/etcd/tests.rs
@@ -222,28 +222,6 @@ async fn test_hardlink_dentry_binding_cross_dir_move_rename() {
 #[serial]
 #[tokio::test]
 #[ignore]
-async fn test_directory_same_parent_rename_updates_lookup() {
-    let store = new_test_store().await;
-    let root = store.root_ino();
-
-    let parent = store.mkdir(root, "parent".to_string()).await.unwrap();
-    let dir_ino = store.mkdir(parent, "old_dir".to_string()).await.unwrap();
-
-    store
-        .rename(parent, "old_dir", parent, "new_dir".to_string())
-        .await
-        .unwrap();
-
-    assert_eq!(store.lookup(parent, "old_dir").await.unwrap(), None);
-    assert_eq!(
-        store.lookup(parent, "new_dir").await.unwrap(),
-        Some(dir_ino)
-    );
-}
-
-#[serial]
-#[tokio::test]
-#[ignore]
 async fn test_basic_read_lock() {
     let store = new_test_store().await;
     let session_id = Uuid::now_v7();

--- a/project/slayerfs/src/meta/stores/redis/mod.rs
+++ b/project/slayerfs/src/meta/stores/redis/mod.rs
@@ -48,6 +48,7 @@ const PLOCK_PREFIX: &str = "plock";
 const LOCKS_KEY: &str = "locks";
 const LOCKED_KEY: &str = "locked";
 const LINK_PARENT_KEY_PREFIX: &str = "lp:";
+const TRUNCATE_REWRITE_MAX_RETRIES: usize = 64;
 
 const CHUNK_ID_BASE: u64 = 1_000_000_000u64;
 
@@ -1194,17 +1195,53 @@ impl RedisMetaStore {
         }
     }
 
-    async fn rewrite_slices(&self, chunk_id: u64, slices: &[SliceDesc]) -> Result<(), MetaError> {
-        let mut conn = self.conn.clone();
+    async fn rewrite_trimmed_slices(
+        &self,
+        chunk_id: u64,
+        cutoff_offset: u64,
+    ) -> Result<(), MetaError> {
         let key = self.chunk_key(chunk_id);
-        let mut pipe = redis::pipe();
-        pipe.atomic().cmd("DEL").arg(&key);
-        for slice in slices {
-            let data = crate::meta::serialization::serialize_meta(slice)?;
-            pipe.cmd("RPUSH").arg(&key).arg(data);
+
+        for _ in 0..TRUNCATE_REWRITE_MAX_RETRIES {
+            let mut conn = Self::create_connection(&self._config).await?;
+
+            redis::cmd("WATCH")
+                .arg(&key)
+                .exec_async(&mut conn)
+                .await
+                .map_err(redis_err)?;
+
+            let raw: Vec<Vec<u8>> = redis::cmd("LRANGE")
+                .arg(&key)
+                .arg(0)
+                .arg(-1)
+                .query_async(&mut conn)
+                .await
+                .map_err(redis_err)?;
+
+            let mut slices = Vec::with_capacity(raw.len());
+            for entry in raw {
+                let desc: SliceDesc = crate::meta::serialization::deserialize_meta(&entry)?;
+                slices.push(desc);
+            }
+            trim_slices_in_place(&mut slices, cutoff_offset);
+
+            let mut pipe = redis::pipe();
+            pipe.atomic().cmd("DEL").arg(&key).ignore();
+            for slice in &slices {
+                let data = crate::meta::serialization::serialize_meta(slice)?;
+                pipe.cmd("RPUSH").arg(&key).arg(data).ignore();
+            }
+
+            let rewritten: Option<()> = pipe.query_async(&mut conn).await.map_err(redis_err)?;
+            if rewritten.is_some() {
+                return Ok(());
+            }
         }
-        pipe.query_async::<()>(&mut conn).await.map_err(redis_err)?;
-        Ok(())
+
+        Err(MetaError::Internal(format!(
+            "truncate rewrite retried too many times for chunk {chunk_id}"
+        )))
     }
 
     async fn shutdown_session_by_id(&self, session_id: Uuid) -> Result<(), MetaError> {
@@ -1268,9 +1305,7 @@ impl RedisMetaStore {
             chunk_size,
             |cutoff_chunk, cutoff_offset| async move {
                 let chunk_id = self.chunk_id(ino, cutoff_chunk);
-                let mut slices = self.get_slices(chunk_id).await?;
-                trim_slices_in_place(&mut slices, cutoff_offset);
-                self.rewrite_slices(chunk_id, &slices).await?;
+                self.rewrite_trimmed_slices(chunk_id, cutoff_offset).await?;
                 Ok(())
             },
             |start, end| async move {

--- a/project/slayerfs/src/vfs/error.rs
+++ b/project/slayerfs/src/vfs/error.rs
@@ -312,31 +312,3 @@ impl From<VfsError> for std::io::Error {
         std::io::Error::new(kind, value.to_string())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::{PathHint, VfsError};
-    use crate::meta::store::MetaError;
-    use std::io::ErrorKind;
-
-    #[test]
-    fn from_meta_preserves_not_directory_semantics() {
-        let err = VfsError::from_meta(PathHint::some("/tmp/dst"), MetaError::NotDirectory(123));
-        assert!(matches!(err, VfsError::NotADirectory { .. }));
-
-        let io_err: std::io::Error = err.into();
-        assert_eq!(io_err.kind(), ErrorKind::NotADirectory);
-    }
-
-    #[test]
-    fn from_meta_preserves_directory_not_empty_semantics() {
-        let err = VfsError::from_meta(
-            PathHint::some("/tmp/dst"),
-            MetaError::DirectoryNotEmpty(123),
-        );
-        assert!(matches!(err, VfsError::DirectoryNotEmpty { .. }));
-
-        let io_err: std::io::Error = err.into();
-        assert_eq!(io_err.kind(), ErrorKind::DirectoryNotEmpty);
-    }
-}

--- a/project/slayerfs/src/vfs/fs/mod.rs
+++ b/project/slayerfs/src/vfs/fs/mod.rs
@@ -9,7 +9,7 @@ use crate::meta::config::MetaClientConfig;
 use crate::meta::file_lock::{FileLockInfo, FileLockQuery, FileLockRange, FileLockType};
 use crate::meta::store::{AclRule, MetaStore, SetAttrFlags, SetAttrRequest, StatFsSnapshot};
 use dashmap::{DashMap, Entry};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -1527,7 +1527,11 @@ where
             guards.push(handle.lock_write().await);
         }
 
-        self.state.writer.flush_if_exists(ino as u64).await;
+        self.state
+            .writer
+            .flush_required(ino as u64)
+            .await
+            .map_err(|_| VfsError::Other)?;
 
         self.meta_truncate(ino, size, self.core.layout.chunk_size)
             .await?;
@@ -1559,14 +1563,24 @@ where
         req: &SetAttrRequest,
         flags: SetAttrFlags,
     ) -> Result<FileAttr, VfsError> {
-        if let Some(size) = req.size {
+        // Hold handle write guards across the ENTIRE truncate + meta_set_attr
+        // sequence so that no concurrent write_ino / FUSE_WRITE_CACHE can modify
+        // the inode between the truncate and the attribute read-back.  Dropping
+        // the guards too early allowed a race where meta_set_attr could read back
+        // a size extended by a concurrent commit, causing the FUSE setattr
+        // response to carry a wrong file size and confusing the kernel page cache.
+        let _guards = if let Some(size) = req.size {
             let handles = self.file_handles_for_inode(ino);
             let mut guards = Vec::with_capacity(handles.len());
             for handle in handles {
                 guards.push(handle.lock_write().await);
             }
 
-            self.state.writer.flush_if_exists(ino as u64).await;
+            self.state
+                .writer
+                .flush_required(ino as u64)
+                .await
+                .map_err(|_| VfsError::Other)?;
             self.meta_truncate(ino, size, self.core.layout.chunk_size)
                 .await?;
             self.state.reader.invalidate_all(ino as u64).await;
@@ -1582,23 +1596,30 @@ where
                 self.state.handles.update_attr_for_inode(ino, &attr);
             }
 
-            drop(guards);
-        }
+            Some(guards)
+        } else {
+            None
+        };
 
         let mut filtered = *req;
         filtered.size = None;
 
-        let attr = self.meta_set_attr(ino, &filtered, flags).await?;
+        let mut attr = self.meta_set_attr(ino, &filtered, flags).await?;
 
-        if let Some(size) = req.size
-            && let Some(inode) = self.state.inodes.get(&ino)
-        {
-            inode.update_size(size);
+        // Ensure the returned attr carries exactly the requested truncation size.
+        // The kernel trusts this value for truncate_pagecache decisions; a stale
+        // or extended size here can cause it to keep or invalidate wrong pages.
+        if let Some(size) = req.size {
+            attr.size = size;
+            if let Some(inode) = self.state.inodes.get(&ino) {
+                inode.update_size(size);
+            }
         }
 
         self.state.modified.touch(ino).await;
         self.state.handles.update_attr_for_inode(ino, &attr);
 
+        // _guards dropped here — after meta_set_attr has read the correct state
         Ok(attr)
     }
 
@@ -1680,6 +1701,16 @@ where
 
         let written = handle.write(offset, data).await?;
 
+        // Invalidate reader cache for the written range so subsequent reads
+        // (including FUSE reads on kernel page-cache miss) see committed data
+        // instead of a stale cached snapshot from before this write.
+        let _ = self
+            .state
+            .reader
+            .invalidate(handle.ino as u64, offset, data.len())
+            .await;
+
+        self.update_mtime_ctime(handle.ino).await?;
         self.state.modified.touch(handle.ino).await;
 
         tracing::trace!(fh, ino = handle.ino, written, "vfs.write_done");
@@ -1690,6 +1721,12 @@ where
     pub async fn write_ino(&self, ino: i64, offset: u64, data: &[u8]) -> Result<usize, VfsError> {
         if data.is_empty() {
             return Ok(0);
+        }
+
+        let handles = self.file_handles_for_inode(ino);
+        let mut guards = Vec::with_capacity(handles.len());
+        for handle in handles {
+            guards.push(handle.lock_write().await);
         }
 
         let attr = self.meta_stat_required(ino, PathHint::none()).await?;
@@ -1708,8 +1745,85 @@ where
             .write_at(offset, data)
             .await
             .map_err(VfsError::from)?;
+        writer.flush().await.map_err(|_| VfsError::Other)?;
 
+        // Invalidate reader cache for the written range so any subsequent
+        // FUSE read (kernel page-cache miss) fetches the freshly committed
+        // data instead of a stale cached zero-fill from a prior truncate.
+        let _ = self
+            .state
+            .reader
+            .invalidate(ino as u64, offset, data.len())
+            .await;
+
+        self.update_mtime_ctime(ino).await?;
         self.state.modified.touch(ino).await;
+        drop(guards);
+        Ok(written)
+    }
+
+    /// Copy a byte range between two opened file handles.
+    ///
+    /// This keeps the copy inside SlayerFS so we can serialize it with the
+    /// inode write path instead of falling back to kernel/user-space emulation.
+    pub async fn copy_file_range(
+        &self,
+        fh_in: u64,
+        off_in: u64,
+        fh_out: u64,
+        off_out: u64,
+        length: u64,
+    ) -> Result<usize, VfsError> {
+        if length == 0 {
+            return Ok(0);
+        }
+
+        let len = usize::try_from(length).map_err(|_| VfsError::InvalidInput)?;
+        let src = self.file_handle_required(fh_in)?;
+        let dst = self.file_handle_required(fh_out)?;
+
+        if !src.flags.read {
+            return Err(VfsError::PermissionDenied {
+                path: PathHint::none(),
+            });
+        }
+        if !dst.flags.write {
+            return Err(VfsError::PermissionDenied {
+                path: PathHint::none(),
+            });
+        }
+
+        let mut locked = Vec::new();
+        let mut unique = BTreeMap::new();
+        for handle in self.file_handles_for_inode(src.ino) {
+            unique.insert(handle.fh, handle);
+        }
+        for handle in self.file_handles_for_inode(dst.ino) {
+            unique.insert(handle.fh, handle);
+        }
+        for handle in unique.into_values() {
+            locked.push(handle.lock_write().await);
+        }
+
+        self.state.writer.flush_if_exists(src.ino as u64).await;
+        if dst.ino != src.ino {
+            self.state.writer.flush_if_exists(dst.ino as u64).await;
+        }
+
+        let src_attr = self.meta_stat_required(src.ino, PathHint::none()).await?;
+        let dst_attr = self.meta_stat_required(dst.ino, PathHint::none()).await?;
+        let src_guard = self.open_guard(src.ino, src_attr, true, false).await?;
+        let dst_guard = self.open_guard(dst.ino, dst_attr, false, true).await?;
+
+        // Read the full source snapshot before writing so same-file overlap keeps
+        // copy_file_range semantics close to a memmove-style copy.
+        let data = src_guard.read(off_in, len).await?;
+        let written = dst_guard.write(off_out, &data).await?;
+
+        drop(dst_guard);
+        drop(src_guard);
+        drop(locked);
+
         Ok(written)
     }
 

--- a/project/slayerfs/src/vfs/fs/tests.rs
+++ b/project/slayerfs/src/vfs/fs/tests.rs
@@ -635,6 +635,130 @@ mod io_tests {
         fs.close(fh).await.unwrap();
     }
 
+    #[tokio::test]
+    async fn test_fs_copy_file_range_same_file_preserves_recent_write_tail() {
+        let layout = ChunkLayout {
+            chunk_size: 512 * 1024,
+            block_size: 4 * 1024,
+        };
+        let store = InMemoryBlockStore::new();
+        let meta_handle = create_meta_store_from_url("sqlite::memory:").await.unwrap();
+        let meta_store = meta_handle.store();
+        let fs = VFS::new(layout, store, meta_store).await.unwrap();
+
+        fs.create_file("/copy.bin").await.unwrap();
+        let attr = fs.stat("/copy.bin").await.unwrap();
+        let fh = fs.open(attr.ino, attr.clone(), true, true).await.unwrap();
+
+        let mut expected = vec![0u8; 0x6f000];
+
+        let mut src = vec![0u8; 0xd000];
+        for (i, b) in src.iter_mut().enumerate() {
+            *b = (0x40u8).wrapping_add(i as u8);
+        }
+        fs.write(fh, 0x5d000, &src).await.unwrap();
+        expected[0x5d000..0x6a000].copy_from_slice(&src);
+
+        let mut tail = vec![0u8; 0xe000];
+        for (i, b) in tail.iter_mut().enumerate() {
+            *b = (0x90u8).wrapping_add((i * 3) as u8);
+        }
+        fs.write(fh, 0x2b000, &tail).await.unwrap();
+        expected[0x2b000..0x39000].copy_from_slice(&tail);
+
+        let copied = fs
+            .copy_file_range(fh, 0x5d000, fh, 0x24000, 0xd000)
+            .await
+            .unwrap();
+        assert_eq!(copied, 0xd000);
+        let copied_view = expected[0x5d000..0x6a000].to_vec();
+        expected[0x24000..0x31000].copy_from_slice(&copied_view);
+
+        let out = fs.read(fh, 0x2c000, 0xa000).await.unwrap();
+        assert_eq!(out, expected[0x2c000..0x36000].to_vec());
+
+        fs.close(fh).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fs_truncate_then_rewrite_range_stays_visible() {
+        let layout = ChunkLayout {
+            chunk_size: 512 * 1024,
+            block_size: 4 * 1024,
+        };
+        let store = InMemoryBlockStore::new();
+        let meta_handle = create_meta_store_from_url("sqlite::memory:").await.unwrap();
+        let meta_store = meta_handle.store();
+        let fs = VFS::new(layout, store, meta_store).await.unwrap();
+
+        fs.create_file("/rewrite.bin").await.unwrap();
+        let attr = fs.stat("/rewrite.bin").await.unwrap();
+        let fh = fs.open(attr.ino, attr.clone(), true, true).await.unwrap();
+
+        fs.truncate_inode(attr.ino, 0x15000).await.unwrap();
+        fs.truncate_inode(attr.ino, 0x50000).await.unwrap();
+
+        let mut first = vec![0u8; 0xf000];
+        for (i, b) in first.iter_mut().enumerate() {
+            *b = (0x31u8).wrapping_add((i * 5) as u8);
+        }
+        fs.write(fh, 0x28000, &first).await.unwrap();
+
+        let mut second = vec![0u8; 0x9000];
+        for (i, b) in second.iter_mut().enumerate() {
+            *b = (0x79u8).wrapping_add((i * 7) as u8);
+        }
+        fs.write(fh, 0x32000, &second).await.unwrap();
+
+        fs.truncate_inode(attr.ino, 0x49000).await.unwrap();
+
+        let out = fs.read(fh, 0x34000, 0x7000).await.unwrap();
+        assert_eq!(out, second[0x2000..0x9000].to_vec());
+
+        fs.close(fh).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_fs_truncate_keeps_prefix_of_overlapping_slice() {
+        let layout = ChunkLayout {
+            chunk_size: 512 * 1024,
+            block_size: 4 * 1024,
+        };
+        let store = InMemoryBlockStore::new();
+        let meta_handle = create_meta_store_from_url("sqlite::memory:").await.unwrap();
+        let meta_store = meta_handle.store();
+        let fs = VFS::new(layout, store, meta_store).await.unwrap();
+
+        fs.create_file("/trimmed-prefix.bin").await.unwrap();
+        let attr = fs.stat("/trimmed-prefix.bin").await.unwrap();
+        let fh = fs.open(attr.ino, attr.clone(), true, true).await.unwrap();
+
+        fs.truncate_inode(attr.ino, 0x35063).await.unwrap();
+
+        let start = 0x1a352u64;
+        let len = 0xb944usize;
+        let mut payload = vec![0u8; len];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = (0x55u8).wrapping_add((i * 11) as u8);
+        }
+        fs.write(fh, start, &payload).await.unwrap();
+
+        fs.truncate_inode(attr.ino, 0x1f76b).await.unwrap();
+        fs.truncate_inode(attr.ino, 0x40000).await.unwrap();
+        fs.truncate_inode(attr.ino, 0x2519b).await.unwrap();
+
+        let read_start = 0x1a593u64;
+        let read_len = 0x3ab1usize;
+        let out = fs.read(fh, read_start, read_len).await.unwrap();
+        let expected_offset = (read_start - start) as usize;
+        assert_eq!(
+            out,
+            payload[expected_offset..expected_offset + read_len].to_vec()
+        );
+
+        fs.close(fh).await.unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_fs_parallel_writes_to_distinct_files() {
         let layout = ChunkLayout {

--- a/project/slayerfs/src/vfs/handles.rs
+++ b/project/slayerfs/src/vfs/handles.rs
@@ -261,6 +261,9 @@ where
                 .ok_or_else(|| anyhow!("file handle writer not initialized"))?
         };
         let written = writer.write_at(offset, data).await?;
+        // Keep write(2) close to POSIX visibility expectations: once the syscall
+        // returns, subsequent truncate/read/copy paths must observe the data.
+        writer.flush().await?;
         self.update_offset(offset + written as u64);
         Ok(written)
     }

--- a/project/slayerfs/src/vfs/io/writer.rs
+++ b/project/slayerfs/src/vfs/io/writer.rs
@@ -1273,6 +1273,18 @@ where
         }
     }
 
+    /// Like `flush_if_exists` but propagates errors.  Used in truncate paths
+    /// where a failed flush means data would be silently lost.
+    pub(crate) async fn flush_required(&self, ino: u64) -> anyhow::Result<()> {
+        let writer = self.files.get(&ino).map(|entry| entry.value().clone());
+        if let Some(writer) = writer
+            && writer.has_pending().await
+        {
+            writer.flush().await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn clear(&self, ino: u64) {
         let writer = self.files.get(&ino).map(|entry| entry.value().clone());
         if let Some(writer) = writer {

--- a/project/slayerfs/src/vfs/meta_ops.rs
+++ b/project/slayerfs/src/vfs/meta_ops.rs
@@ -1,9 +1,7 @@
 //! Thin wrappers around [`MetaLayer`] methods used by the VFS.
 //!
-//! Every method here converts `MetaError` → `VfsError` via `VfsError::from_meta`,
-//! preserving filesystem-specific error semantics instead of collapsing them
-//! into a generic wrapper that later turns into `EIO`.
-//! This keeps the call sites in `fs.rs` free of repetitive boilerplate.
+//! Every method here converts `MetaError` → `VfsError` via `VfsError::from`,
+//! keeping the call sites in `fs.rs` free of repetitive boilerplate.
 //! The three composite helpers (`meta_lookup_required`, `meta_stat_required`,
 //! `meta_lookup_path_required`) that were previously at the bottom of `fs.rs` live
 //! here as well, since they are purely metadata-layer concerns.
@@ -33,7 +31,7 @@ where
 
     /// Fetch attributes for `ino`, returning `None` when the inode is absent.
     pub(super) async fn meta_stat(&self, ino: i64) -> Result<Option<FileAttr>, VfsError> {
-        self.meta_layer().stat(ino).await.map_err(meta_err_to_vfs)
+        self.meta_layer().stat(ino).await.map_err(VfsError::from)
     }
 
     /// Fetch fresh (uncached) attributes for `ino`, returning `None` when absent.
@@ -41,7 +39,7 @@ where
         self.meta_layer()
             .stat_fresh(ino)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------
@@ -57,7 +55,7 @@ where
         self.meta_layer()
             .lookup(parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_lookup_required(
@@ -69,7 +67,7 @@ where
         self.meta_layer()
             .lookup(parent, name)
             .await
-            .map_err(meta_err_to_vfs)?
+            .map_err(VfsError::from)?
             .ok_or_else(|| VfsError::NotFound { path: hint })
     }
 
@@ -81,7 +79,7 @@ where
         self.meta_layer()
             .lookup_path(path)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------
@@ -108,14 +106,14 @@ where
         self.meta_layer()
             .mkdir(parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_rmdir(&self, parent: i64, name: &str) -> Result<(), VfsError> {
         self.meta_layer()
             .rmdir(parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_readdir(&self, ino: i64) -> Result<Vec<DirEntry>, VfsError> {
@@ -145,7 +143,7 @@ where
         self.meta_layer()
             .create_file(parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_link(
@@ -157,7 +155,7 @@ where
         self.meta_layer()
             .link(ino, parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_symlink(
@@ -169,14 +167,14 @@ where
         self.meta_layer()
             .symlink(parent, name, target)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_unlink(&self, parent: i64, name: &str) -> Result<(), VfsError> {
         self.meta_layer()
             .unlink(parent, name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------
@@ -193,7 +191,7 @@ where
         self.meta_layer()
             .rename(old_parent, old_name, new_parent, new_name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_rename_exchange(
@@ -206,7 +204,7 @@ where
         self.meta_layer()
             .rename_exchange(old_parent, old_name, new_parent, new_name)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------
@@ -222,14 +220,14 @@ where
         self.meta_layer()
             .set_attr(ino, req, flags)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_chmod(&self, ino: i64, new_mode: u32) -> Result<FileAttr, VfsError> {
         self.meta_layer()
             .chmod(ino, new_mode)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_chown(
@@ -241,7 +239,7 @@ where
         self.meta_layer()
             .chown(ino, uid, gid)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_truncate(
@@ -253,7 +251,7 @@ where
         self.meta_layer()
             .truncate(ino, size, chunk_size)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------
@@ -264,21 +262,21 @@ where
         self.meta_layer()
             .read_symlink(ino)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_get_dir_parent(&self, ino: i64) -> Result<Option<i64>, VfsError> {
         self.meta_layer()
             .get_dir_parent(ino)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     pub(super) async fn meta_get_paths(&self, ino: i64) -> Result<Vec<String>, VfsError> {
         self.meta_layer()
             .get_paths(ino)
             .await
-            .map_err(meta_err_to_vfs)
+            .map_err(VfsError::from)
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
…ngle slices after truncate; fix xfstests read-bad-data

Update append_slice/replace_slices to only modify existing cache entries, avoiding insertion of incomplete per-chunk lists from a single slice.

Remove mount option custom_options(sync) (clean up an unnecessary workaround).

Fix cache race between truncate and subsequent writes that caused READ BAD DATA in xfstests generic/091 and generic/112; targeted tests have passed.