### PR TITLE
Stabilize Redis xfstests runner in SlayerFS

### DIFF
--- a/project/slayerfs/docker/compose-xfstests/Dockerfile
+++ b/project/slayerfs/docker/compose-xfstests/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.88-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/local/cargo/bin:/usr/local/rustup/bin:${PATH}"
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sudo ca-certificates git curl fuse3 redis-server \
+    acl attr automake bc dbench dump e2fsprogs fio gawk gcc indent \
+    libacl1-dev libaio-dev libcap-dev libgdbm-dev libtool libtool-bin \
+    liburing-dev libuuid1 lvm2 make psmisc python3 quota sed uuid-dev \
+    uuid-runtime xfsprogs exfatprogs f2fs-tools ocfs2-tools udftools \
+    xfsdump xfslibs-dev protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/rk8s

--- a/project/slayerfs/docker/compose-xfstests/run_redis_xfstests.sh
+++ b/project/slayerfs/docker/compose-xfstests/run_redis_xfstests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+slayerfs_dir=$(cd "$current_dir/../.." && pwd)
+repo_root=$(cd "$slayerfs_dir/../.." && pwd)
+artifacts_dir="$current_dir/artifacts"
+image_name="slayerfs-xfstests-runner:local"
+
+mkdir -p "$artifacts_dir"
+
+echo "[1/3] Building xfstests runner image..."
+docker build -t "$image_name" -f "$current_dir/Dockerfile" "$current_dir"
+
+echo "[2/3] Running Redis xfstests in container..."
+set +e
+docker run --rm --privileged --network host \
+  -e XFSTESTS_CASES="${XFSTESTS_CASES:-generic/001 generic/013 generic/023 generic/035}" \
+  -e XFSTESTS_BRANCH="${XFSTESTS_BRANCH:-v2023.12.10}" \
+  -v "$repo_root:/workspace/rk8s" \
+  -v "$artifacts_dir:/artifacts" \
+  "$image_name" \
+  bash -lc '
+    set -euo pipefail
+    export PATH="/usr/local/cargo/bin:/usr/local/rustup/bin:$PATH"
+    cd /workspace/rk8s/project/slayerfs
+
+    cargo build -p slayerfs --example persistence_demo --release
+
+    export SLAYERFS_CONFIG=/workspace/rk8s/project/slayerfs/redis.yml
+    export slayerfs_rust_log="${slayerfs_rust_log:-slayerfs=info,rfuse3::raw::logfs=warn}"
+    export slayerfs_fuse_op_log="${slayerfs_fuse_op_log:-0}"
+
+    set +e
+    bash tests/scripts/xfstests_slayer.sh
+    run_status=$?
+
+    cp -f /tmp/slayerfs.log /artifacts/slayerfs.log 2>/dev/null || true
+    cp -rf /tmp/xfstests-dev/results /artifacts/results 2>/dev/null || true
+    cp -f /tmp/xfstests-dev/check.log /artifacts/check.log 2>/dev/null || true
+
+    exit $run_status
+  '
+run_status=$?
+set -e
+
+echo "[3/3] Collecting artifacts..."
+echo "Artifacts written to: $artifacts_dir"
+
+if [[ $run_status -ne 0 ]]; then
+  echo "xfstests exited with status $run_status"
+  echo "See artifacts under: $artifacts_dir"
+  exit $run_status
+fi
+
+echo "xfstests completed. Artifacts: $artifacts_dir"

--- a/project/slayerfs/src/fuse/adapter.rs
+++ b/project/slayerfs/src/fuse/adapter.rs
@@ -1,6 +1,0 @@
-//! FUSE adapter glue code (placeholder)
-
-#[allow(dead_code)]
-pub(crate) fn register_callbacks() {
-    // TODO: register FUSE handlers
-}

--- a/project/slayerfs/src/fuse/mod.rs
+++ b/project/slayerfs/src/fuse/mod.rs
@@ -4,7 +4,6 @@
 //! to the operating system via the FUSE protocol.
 //!
 //! Main components:
-//! - `adapter`: Contains the FUSE adapter implementation.
 //! - `mount`: Handles mounting the virtual filesystem using FUSE.
 //! - Implementation of the `Filesystem` trait for `VFS`, enabling translation of FUSE requests
 //!   into virtual filesystem operations.
@@ -12,7 +11,6 @@
 //!
 //! The module also includes platform-specific tests for mounting and basic operations,
 //! and provides utilities for mapping VFS metadata to FUSE attributes.
-pub(crate) mod adapter;
 pub mod mount;
 use crate::chunk::store::BlockStore;
 use crate::meta::MetaLayer;
@@ -97,6 +95,9 @@ mod mount_tests {
         }
         let content = fs::read(&file_path).expect("read back");
         assert_eq!(content, b"abc");
+
+        // POSIX: rename(path, path) is a no-op and must succeed.
+        fs::rename(&file_path, &file_path).expect("rename same path no-op");
 
         // List the directory
         let list = fs::read_dir(&dir)
@@ -1008,9 +1009,9 @@ where
             return Err(libc::EINVAL.into());
         }
 
-        // Prevent renaming to the same location
+        // POSIX allows same-path rename as a no-op.
         if parent == new_parent && name == new_name {
-            return Err(libc::EINVAL.into());
+            return Ok(());
         }
 
         // Ensure the source exists

--- a/project/slayerfs/src/meta/stores/redis/mod.rs
+++ b/project/slayerfs/src/meta/stores/redis/mod.rs
@@ -133,22 +133,26 @@ const UNLINK_LUA: &str = r#"
     local name = ARGV[2]
     local timestamp = tonumber(ARGV[3])
 
-    -- Remove from directory (idempotent)
-    redis.call('HDEL', dir_key, name)
+    local dentry_ino = redis.call('HGET', dir_key, name)
+    if not dentry_ino then
+        return cjson.encode({ok=false, error="not_found"})
+    end
 
-    -- Remove from link_parents (idempotent)
-    local member = parent_ino .. ":" .. name
-    redis.call('SREM', lp_key, member)
-
-    -- Try to get node
+    -- Node must exist; otherwise we are in inconsistent or raced state.
     local node_json = redis.call('GET', node_key)
     if not node_json then
-        return cjson.encode({ok=true, nlink=0, deleted=true})
+        return cjson.encode({ok=false, error="node_not_found"})
     end
     local ok, node = pcall(cjson.decode, node_json)
     if not ok or not node or not node.attr then
-        return cjson.encode({ok=true, nlink=0, deleted=true})
+        return cjson.encode({ok=false, error="corrupt_node"})
     end
+
+    -- Remove from directory and link_parents once validation passes.
+    redis.call('HDEL', dir_key, name)
+
+    local member = parent_ino .. ":" .. name
+    redis.call('SREM', lp_key, member)
 
     -- Decrement nlink
     if node.attr.nlink > 0 then
@@ -335,7 +339,7 @@ const CREATE_ENTRY_LUA: &str = r#"
     return cjson.encode({ok=true, ino=new_ino})
 "#;
 
-// Lua script for atomically renaming file or directory (no overwrite)
+// Lua script for atomically renaming file or directory (with replacement)
 const RENAME_LUA: &str = r#"
     local cjson = cjson
 
@@ -370,13 +374,7 @@ const RENAME_LUA: &str = r#"
         return cjson.encode({ok=false, error="parent_not_directory", ino=new_parent_ino})
     end
 
-    -- 3. Check target doesn't exist
-    local target_exists = redis.call('HEXISTS', new_parent_dir_key, new_name)
-    if target_exists == 1 then
-        return cjson.encode({ok=false, error="already_exists"})
-    end
-
-    -- 4. Get child node
+    -- 3. Get child node
     local child_json = redis.call('GET', child_node_key)
     if not child_json then
         return cjson.encode({ok=false, error="node_not_found", ino=tonumber(dentry_ino)})
@@ -386,7 +384,89 @@ const RENAME_LUA: &str = r#"
         return cjson.encode({ok=false, error="corrupt_node"})
     end
 
-    -- 5. Update node parent/name OR link_parents based on nlink
+    -- 4. Resolve target entry. Replacement is handled in this script atomically.
+    local target_ino = redis.call('HGET', new_parent_dir_key, new_name)
+    if target_ino then
+        local src_ino_num = tonumber(dentry_ino)
+        local target_ino_num = tonumber(target_ino)
+
+        -- If source and destination already point to the same inode, treat as no-op.
+        if src_ino_num ~= target_ino_num then
+            local target_node_key = 'i' .. target_ino_num
+            local target_json = redis.call('GET', target_node_key)
+            if not target_json then
+                return cjson.encode({ok=false, error="node_not_found", ino=target_ino_num})
+            end
+
+            local ok_target, target_node = pcall(cjson.decode, target_json)
+            if not ok_target or not target_node or not target_node.attr then
+                return cjson.encode({ok=false, error="corrupt_node"})
+            end
+
+            local src_is_dir = child_node.kind == 'Dir'
+            local dst_is_dir = target_node.kind == 'Dir'
+
+            if src_is_dir and not dst_is_dir then
+                return cjson.encode({ok=false, error="dest_not_directory", ino=target_ino_num})
+            end
+
+            if (not src_is_dir) and dst_is_dir then
+                return cjson.encode({ok=false, error="dest_is_directory", ino=target_ino_num})
+            end
+
+            if src_is_dir and dst_is_dir then
+                local target_dir_key = 'd' .. target_ino_num
+                local target_children = redis.call('HLEN', target_dir_key)
+                if target_children > 0 then
+                    return cjson.encode({ok=false, error="dir_not_empty", ino=target_ino_num})
+                end
+
+                redis.call('HDEL', new_parent_dir_key, new_name)
+                redis.call('DEL', target_node_key)
+                redis.call('DEL', target_dir_key)
+
+                if new_parent_node.attr and new_parent_node.attr.nlink then
+                    new_parent_node.attr.nlink = new_parent_node.attr.nlink - 1
+                end
+            else
+                redis.call('HDEL', new_parent_dir_key, new_name)
+
+                local target_lp_key = 'lp:' .. target_ino_num
+                local target_member = new_parent_ino .. ':' .. new_name
+                redis.call('SREM', target_lp_key, target_member)
+
+                if target_node.attr.nlink and target_node.attr.nlink > 0 then
+                    target_node.attr.nlink = target_node.attr.nlink - 1
+                end
+                target_node.attr.ctime = timestamp
+
+                if target_node.attr.nlink == 0 then
+                    redis.call('DEL', target_node_key)
+                    redis.call('DEL', target_lp_key)
+                else
+                    if target_node.attr.nlink == 1 then
+                        local remaining_members = redis.call('SMEMBERS', target_lp_key)
+                        if #remaining_members == 1 then
+                            local sep_pos = string.find(remaining_members[1], ':', 1, true)
+                            if sep_pos and sep_pos > 1 and sep_pos < #remaining_members[1] then
+                                local parent_str = string.sub(remaining_members[1], 1, sep_pos - 1)
+                                local name_str = string.sub(remaining_members[1], sep_pos + 1)
+                                local parent_num = tonumber(parent_str)
+                                if parent_num then
+                                    target_node.parent = parent_num
+                                    target_node.name = name_str
+                                end
+                            end
+                        end
+                        redis.call('DEL', target_lp_key)
+                    end
+                    redis.call('SET', target_node_key, cjson.encode(target_node))
+                end
+            end
+        end
+    end
+
+    -- 5. Update source node parent/name OR link_parents based on nlink
     if child_node.attr.nlink <= 1 then
         -- Single parent: update node directly
         child_node.parent = new_parent_ino
@@ -1488,10 +1568,13 @@ impl MetaStore for RedisMetaStore {
             .map_err(|e| MetaError::Internal(format!("Lua response parse error: {e}")))?;
 
         if !response.ok {
-            let err = response
-                .error
-                .unwrap_or_else(|| "unknown error".to_string());
-            return Err(MetaError::Internal(format!("Lua error: {err}")));
+            return match response.error.as_deref() {
+                Some("not_found") => Err(MetaError::NotFound(parent)),
+                Some("node_not_found") => Err(MetaError::NotFound(child)),
+                Some("corrupt_node") => Err(MetaError::Internal("corrupt node data".into())),
+                Some(other) => Err(MetaError::Internal(format!("Lua error: {other}"))),
+                None => Err(MetaError::Internal("unexpected Lua response".into())),
+            };
         }
 
         let nlink = response.nlink.unwrap_or(0);
@@ -1587,6 +1670,11 @@ impl MetaStore for RedisMetaStore {
             Some("not_found") => Err(MetaError::NotFound(response.ino.unwrap_or(old_parent))),
             Some("parent_not_found") => Err(MetaError::ParentNotFound(new_parent)),
             Some("parent_not_directory") => Err(MetaError::NotDirectory(new_parent)),
+            Some("dest_not_directory") => Err(MetaError::NotDirectory(response.ino.unwrap_or(0))),
+            Some("dest_is_directory") => Err(MetaError::NotDirectory(response.ino.unwrap_or(0))),
+            Some("dir_not_empty") => {
+                Err(MetaError::DirectoryNotEmpty(response.ino.unwrap_or(0)))
+            }
             Some("already_exists") => Err(MetaError::AlreadyExists {
                 parent: new_parent,
                 name: new_name,

--- a/project/slayerfs/src/meta/stores/redis/tests.rs
+++ b/project/slayerfs/src/meta/stores/redis/tests.rs
@@ -1139,26 +1139,127 @@ async fn test_rename_lua_target_exists() {
     let store = new_test_store().await;
     let root = store.root_ino();
 
-    store
+    let src_ino = store
         .create_file(root, "file1.txt".to_string())
         .await
         .unwrap();
-    store
+    let dst_ino = store
         .create_file(root, "file2.txt".to_string())
         .await
         .unwrap();
 
-    let result = store
+    store
         .rename(root, "file1.txt", root, "file2.txt".to_string())
-        .await;
+        .await
+        .unwrap();
+
+    // Destination should now point to source inode and old source name must disappear.
+    assert_eq!(store.lookup(root, "file1.txt").await.unwrap(), None);
+    assert_eq!(store.lookup(root, "file2.txt").await.unwrap(), Some(src_ino));
+
+    // Old destination inode should be deleted.
+    assert!(store.stat(dst_ino).await.unwrap().is_none());
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_rename_lua_replace_is_atomic_against_concurrent_create() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+
+    let src_ino = store
+        .create_file(root, "src.txt".to_string())
+        .await
+        .unwrap();
+    let dst_ino = store
+        .create_file(root, "dst.txt".to_string())
+        .await
+        .unwrap();
+
+    let rename_store = store.clone();
+    let create_store = store.clone();
+
+    let rename_task = tokio::spawn(async move {
+        rename_store
+            .rename(root, "src.txt", root, "dst.txt".to_string())
+            .await
+    });
+
+    // Try to create the destination repeatedly while rename is in flight.
+    let create_task = tokio::spawn(async move {
+        let mut already_exists = 0usize;
+        for _ in 0..32 {
+            match create_store.create_file(root, "dst.txt".to_string()).await {
+                Ok(_) => return Err("create unexpectedly succeeded during rename".to_string()),
+                Err(MetaError::AlreadyExists { .. }) => already_exists += 1,
+                Err(other) => {
+                    return Err(format!(
+                        "create returned unexpected error during rename: {:?}",
+                        other
+                    ));
+                }
+            }
+        }
+        Ok(already_exists)
+    });
+
+    rename_task.await.unwrap().unwrap();
+    let create_attempts = create_task.await.unwrap().unwrap();
+    assert!(create_attempts > 0, "expected concurrent create attempts");
+
+    // Destination now points to source inode and old destination inode is removed.
+    assert_eq!(store.lookup(root, "src.txt").await.unwrap(), None);
+    assert_eq!(store.lookup(root, "dst.txt").await.unwrap(), Some(src_ino));
+    assert!(store.stat(dst_ino).await.unwrap().is_none());
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_unlink_lua_missing_entry_returns_not_found() {
+    let store = new_test_store().await;
+    let root = store.root_ino();
+
+    let result = store.unlink(root, "missing.txt").await;
     assert!(result.is_err());
     match result.unwrap_err() {
-        MetaError::AlreadyExists { parent, name } => {
-            assert_eq!(parent, root);
-            assert_eq!(name, "file2.txt");
-        }
-        other => panic!("expected AlreadyExists error, got {:?}", other),
+        MetaError::NotFound(ino) => assert_eq!(ino, root),
+        other => panic!("expected NotFound(parent) error, got {:?}", other),
     }
+}
+
+#[serial]
+#[tokio::test]
+#[ignore]
+async fn test_unlink_lua_concurrent_double_delete_returns_not_found_for_second() {
+    let store = Arc::new(new_test_store().await);
+    let root = store.root_ino();
+
+    store
+        .create_file(root, "victim.txt".to_string())
+        .await
+        .unwrap();
+
+    let s1 = store.clone();
+    let s2 = store.clone();
+
+    let h1 = tokio::spawn(async move { s1.unlink(root, "victim.txt").await });
+    let h2 = tokio::spawn(async move { s2.unlink(root, "victim.txt").await });
+
+    let r1 = h1.await.unwrap();
+    let r2 = h2.await.unwrap();
+
+    let success_count = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+    assert_eq!(success_count, 1, "exactly one unlink should succeed");
+
+    let not_found_count = [&r1, &r2]
+        .iter()
+        .filter(|r| matches!(r, Err(MetaError::NotFound(ino)) if *ino == root))
+        .count();
+    assert_eq!(not_found_count, 1, "second unlink should return NotFound(parent)");
+
+    assert_eq!(store.lookup(root, "victim.txt").await.unwrap(), None);
 }
 
 #[serial]

--- a/project/slayerfs/src/vfs/fs/mod.rs
+++ b/project/slayerfs/src/vfs/fs/mod.rs
@@ -1160,6 +1160,7 @@ where
             .await?;
 
         // Handle destination existence and replacement semantics
+        let should_predelete_destination = self.meta_layer().name() != "redis-meta-store";
         let dst_path = format!("{}{}{}", dir, if dir == "/" { "" } else { "/" }, new_name);
         if let Some((dest_ino, dest_kind)) = self.meta_lookup_path(&dst_path).await? {
             // Handle replacement logic (same as in main rename function)
@@ -1175,7 +1176,9 @@ where
                             )),
                         });
                     }
-                    self.meta_rmdir(parent_ino, new_name).await?;
+                    if should_predelete_destination {
+                        self.meta_rmdir(parent_ino, new_name).await?;
+                    }
                 }
                 // Directory replacing file/symlink - not allowed
                 (FileType::Dir, FileType::File) | (FileType::Dir, FileType::Symlink) => {
@@ -1197,7 +1200,9 @@ where
                 }
                 // File/symlink replacing file/symlink - allowed
                 _ => {
-                    self.meta_unlink(parent_ino, new_name).await?;
+                    if should_predelete_destination {
+                        self.meta_unlink(parent_ino, new_name).await?;
+                    }
                 }
             }
         }
@@ -1238,6 +1243,11 @@ where
         new_parent_ino: i64,
         new_name: &str,
     ) -> Result<(), VfsError> {
+        // Redis backend performs destination replacement atomically in store-level rename.
+        // Keep VFS-level validation, but avoid pre-deleting destination to prevent
+        // delete-then-rename races under concurrent updates.
+        let should_predelete_destination = self.meta_layer().name() != "redis-meta-store";
+
         if let Some((dest_ino, dest_kind)) = self.meta_lookup_path(new_path).await? {
             match (src_kind, dest_kind) {
                 // Directory → Directory: only if destination is empty
@@ -1253,7 +1263,9 @@ where
                         });
                     }
 
-                    self.meta_rmdir(new_parent_ino, new_name).await?;
+                    if should_predelete_destination {
+                        self.meta_rmdir(new_parent_ino, new_name).await?;
+                    }
                 }
 
                 // Directory → File/Symlink: not allowed
@@ -1281,7 +1293,9 @@ where
                 | (FileType::File, FileType::Symlink)
                 | (FileType::Symlink, FileType::File)
                 | (FileType::Symlink, FileType::Symlink) => {
-                    self.meta_unlink(new_parent_ino, new_name).await?;
+                    if should_predelete_destination {
+                        self.meta_unlink(new_parent_ino, new_name).await?;
+                    }
                 }
             }
         }

--- a/project/slayerfs/tests/scripts/xfstests_slayer.sh
+++ b/project/slayerfs/tests/scripts/xfstests_slayer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 current_dir=$(dirname "$(realpath "$0")")
 workspace_dir=$(realpath "$current_dir/../../..")
-redis_config="$workspace_dir/slayerfs/slayerfs-sqlite.yml"
+slayerfs_config="${SLAYERFS_CONFIG:-$workspace_dir/slayerfs/redis.yml}"
 backend_dir=/tmp/data
 mount_dir=/tmp/mount
 log_file=/tmp/slayerfs.log
@@ -34,7 +34,7 @@ sudo apt-get update
 sudo apt-get install -y acl attr automake bc dbench dump e2fsprogs fio gawk \
     gcc git indent libacl1-dev libaio-dev libcap-dev libgdbm-dev libtool \
     libtool-bin liburing-dev libuuid1 lvm2 make psmisc python3 quota sed \
-    uuid-dev uuid-runtime xfsprogs sqlite3 \
+    uuid-dev uuid-runtime xfsprogs sqlite3 redis-server \
     fuse3
 sudo apt-get install -y exfatprogs f2fs-tools ocfs2-tools udftools xfsdump \
     xfslibs-dev
@@ -68,7 +68,7 @@ set -euo pipefail
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\$PATH"
 
 ulimit -n 1048576
-CONFIG_PATH="$redis_config"
+CONFIG_PATH="$slayerfs_config"
 LOG_FILE="$log_file"
 PERSISTENCE_BIN="$persistence_bin"
 
@@ -88,6 +88,12 @@ fi
 sleep 1
 EOF
 sudo chmod +x /usr/sbin/mount.fuse.slayerfs
+
+# Start Redis when config uses Redis backend.
+if grep -qE '^\s*type:\s*redis\b' "$slayerfs_config"; then
+    sudo redis-cli ping >/dev/null 2>&1 || sudo redis-server --daemonize yes
+    sudo redis-cli ping >/dev/null
+fi
 
 echo "====> Start to run xfstests."
 # Copy exclude list


### PR DESCRIPTION
本 PR 针对 Redis 元数据后端与 FUSE/VFS 语义不一致的问题进行修复，重点覆盖以下风险：

1. 覆盖式 rename 缺少端到端原子性，存在并发竞态下误删目标的可能。
2. unlink 在节点缺失或损坏时存在吞错行为，削弱错误可观测性。
3. FUSE 层同路径 rename 返回 EINVAL，与 POSIX no-op 语义不一致。
4. FUSE 模块结构中占位 adapter 容易误导真实入口，带来维护风险。

**### 主要改动**

1) Redis rename 改为原子替换语义
- 在 Redis Lua rename 脚本中实现目标替换与源移动的单次原子流程。
- 覆盖式重命名时在脚本内完成目标类型校验、目录非空判断、目标删除与源项迁移，避免 VFS 先删后改名导致的竞态窗口。
- 针对硬链接场景同步维护 link_parents 与 nlink 变化。

2) 收紧 UNLINK_LUA 语义
- 目录项不存在时返回 not_found。
- 节点不存在时返回 node_not_found。
- 节点损坏时返回 corrupt_node。
- Rust 层按上述错误进行显式映射，不再将异常状态统一吞为成功删除。

3) 修复 FUSE 同路径 rename 语义
- FUSE rename 在 parent/new_parent 与 name/new_name 相同场景下改为直接成功返回（no-op），与 POSIX 语义对齐。

4) 清理 FUSE 结构误导点（5.4）
- 移除未使用且仅占位的 adapter 模块，避免误导真实实现入口。
- 同步更新模块说明，聚焦实际的 FUSE 实现位置。

**### 测试与回归保障**

新增/更新了 Redis 相关回归测试，覆盖以下关键场景：
1. 目标已存在时 rename 应执行原子替换，而非返回 AlreadyExists。
2. 覆盖式 rename 与并发 create 竞争时不应出现“先删后失败”的可见窗口。
3. 并发双重 unlink 应表现为一次成功、一次 NotFound。
4. FUSE 挂载烟测增加同路径 rename no-op 断言，防止接口语义回退。

**兼容性与风险评估**
- 行为变化主要集中在 Redis 后端语义增强与错误码收敛，目标是向 POSIX 一致性靠拢。
- 非 Redis 后端逻辑保持最小扰动。
- 主要风险点在 rename 替换路径与硬链接维护分支，已通过对应测试覆盖关键回归面。