### PR TITLE
fix(distribution,rkforge): harden resumable blob push retries

### DIFF
--- a/project/Cargo.lock
+++ b/project/Cargo.lock
@@ -145,15 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-build"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac4c64175d504608cf239756339c07f6384a476f97f20a7043f92920b0b8fd"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,16 +2292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,19 +2320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.115",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,17 +2337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
  "quote",
  "syn 2.0.115",
 ]
@@ -2662,17 +2619,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
-dependencies = [
- "libc",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -3534,23 +3480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gm-quic"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9881b922b998efb26b020ff6e452e76a0dc859ff191c911ef564b8cb3209f"
-dependencies = [
- "bytes",
- "dashmap",
- "derive_more 2.1.1",
- "futures",
- "qconnection",
- "rustls 0.23.36",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "go-defer"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4100,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -5349,12 +5278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac-addr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
-
-[[package]]
 name = "macaddr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,12 +5494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "netavark"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5613,24 +5530,6 @@ dependencies = [
  "tonic-prost-build",
  "tower",
  "zbus",
-]
-
-[[package]]
-name = "netdev"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a703aa1a87cd885b9f674922445a42dbb0c0f4f1b28fef21b227ae32375d21"
-dependencies = [
- "dlopen2",
- "ipnet",
- "libc",
- "mac-addr",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-sys",
- "once_cell",
- "system-configuration 0.6.1",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5679,19 +5578,6 @@ dependencies = [
  "libc",
  "log",
  "tokio",
-]
-
-[[package]]
-name = "netwatcher"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d9eee015f242646a9bad2d6ea668651a6c053d0065bec923107b0a43e89a69"
-dependencies = [
- "android-build",
- "jni",
- "ndk-context",
- "nix 0.29.0",
- "windows 0.56.0",
 ]
 
 [[package]]
@@ -7120,112 +7006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qbase"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2634399a2eca401b140b1e89ce7f326cc816de487e01c76350d9439a7e5cd176"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "derive_more 2.1.1",
- "enum_dispatch",
- "futures",
- "getset",
- "http 1.4.0",
- "netdev",
- "nom 8.0.0",
- "qmacro",
- "rand 0.9.2",
- "rustls 0.23.36",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "qcongestion"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1d18c9321ffba0ba83316fc4d3ec687a8a6c3d4d3532ed7105c98cba5556b6"
-dependencies = [
- "qbase",
- "qevent",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "qconnection"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f561741b24076d3160bb7e6f1a4de88f5aed3d14c9fc13a94dcf37ace2cc77a"
-dependencies = [
- "bytes",
- "dashmap",
- "derive_more 2.1.1",
- "enum_dispatch",
- "futures",
- "qbase",
- "qcongestion",
- "qevent",
- "qinterface",
- "qrecovery",
- "qunreliable",
- "ring",
- "rustls 0.23.36",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "x509-parser",
-]
-
-[[package]]
-name = "qevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fad07cca1bfadc0be7cd1dbda15746ef9b17c41e3f8184b3ac34395a97443"
-dependencies = [
- "bytes",
- "derive_builder",
- "derive_more 2.1.1",
- "enum_dispatch",
- "pin-project-lite",
- "qbase",
- "serde",
- "serde_json",
- "serde_with",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "qinterface"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f80d6741a8bf91671d4f5908681f80f20a9aaa5b2dfba09457ff17d95eeb3bd4"
-dependencies = [
- "bytes",
- "dashmap",
- "derive_more 2.1.1",
- "futures",
- "netdev",
- "netwatcher",
- "qbase",
- "qevent",
- "qudp",
- "rustls 0.23.36",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "qlean"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7257,71 +7037,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "qmacro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3859df78e87e8fb5bba0172fccce01e1e41f73719def9c93333c5f817ccfcd52"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
 name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
  "image",
-]
-
-[[package]]
-name = "qrecovery"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ade4f96f651319f887de2f696161561068cabb50a30868b4fb7ace30969b7c2"
-dependencies = [
- "bytes",
- "derive_more 2.1.1",
- "enum_dispatch",
- "futures",
- "qbase",
- "qevent",
- "rand 0.9.2",
- "rustls 0.23.36",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "qudp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9238fe8ac28f5b2f403b7f62a8cfc0ba42c24d9346795036c7af429103bba3b4"
-dependencies = [
- "bytes",
- "cfg-if",
- "libc",
- "nix 0.30.1",
- "socket2 0.6.2",
- "tokio",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "quic_test"
-version = "0.1.0"
-dependencies = [
- "gm-quic",
- "rustls 0.23.36",
- "rustls-pemfile",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -7399,19 +7120,6 @@ dependencies = [
  "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "qunreliable"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d696ab6023d0f13ca2ad6377c779b87881dbdbacad63a8d50c2a98f96e3a004"
-dependencies = [
- "bytes",
- "futures",
- "qbase",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -9803,17 +9511,6 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
@@ -10164,7 +9861,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -11212,16 +10908,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
-dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -11274,24 +10960,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
-dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -11303,8 +10977,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -11334,31 +11008,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11417,15 +11069,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/project/distribution/src/error.rs
+++ b/project/distribution/src/error.rs
@@ -244,13 +244,14 @@ impl IntoResponse for HeaderError {
                 name,
                 current_size,
             } => {
-                return Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::RANGE_NOT_SATISFIABLE)
                     .header(LOCATION, format!("/v2/{name}/blobs/uploads/{session_id}"))
-                    .header(RANGE, format!("0-{}", current_size.saturating_sub(1)))
-                    .header("Docker-Upload-UUID", session_id)
-                    .body(Body::empty())
-                    .unwrap();
+                    .header("Docker-Upload-UUID", session_id);
+                if current_size > 0 {
+                    builder = builder.header(RANGE, format!("0-{}", current_size - 1));
+                }
+                return builder.body(Body::empty()).unwrap();
             }
         };
         oci_error.into_response()

--- a/project/distribution/src/service/blob.rs
+++ b/project/distribution/src/service/blob.rs
@@ -145,6 +145,12 @@ pub async fn patch_blob_handler(
         return Err(OciError::NameInvalid(name).into());
     }
 
+    let session_lock = state
+        .get_session_lock(&session_id)
+        .await
+        .ok_or_else(|| OciError::BlobUploadUnknown(session_id.clone()))?;
+    let _session_guard = session_lock.lock().await;
+
     let session = state
         .get_session(&session_id)
         .await
@@ -174,15 +180,16 @@ pub async fn patch_blob_handler(
         .ok_or_else(|| OciError::BlobUploadUnknown(session_id.clone()))?;
 
     let location = format!("/v2/{name}/blobs/uploads/{session_id}");
-    let end_of_range = new_total_size.saturating_sub(1);
+    let range = upload_range_header(new_total_size);
 
-    Ok(Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::ACCEPTED)
         .header(LOCATION, location)
-        .header(RANGE, format!("0-{end_of_range}"))
-        .header("Docker-Upload-UUID", &session_id)
-        .body(Body::empty())
-        .unwrap())
+        .header("Docker-Upload-UUID", &session_id);
+    if let Some(range) = range {
+        builder = builder.header(RANGE, range);
+    }
+    Ok(builder.body(Body::empty()).unwrap())
 }
 
 pub async fn put_blob_handler(
@@ -191,6 +198,12 @@ pub async fn put_blob_handler(
     Query(params): Query<HashMap<String, String>>,
     request: Request,
 ) -> Result<impl IntoResponse, AppError> {
+    let session_lock = state
+        .get_session_lock(&session_id)
+        .await
+        .ok_or_else(|| OciError::BlobUploadUnknown(session_id.clone()))?;
+    let _session_guard = session_lock.lock().await;
+
     state
         .get_session(&session_id)
         .await
@@ -206,8 +219,9 @@ pub async fn put_blob_handler(
     let body = request.into_body().into_data_stream();
 
     state.storage.write_upload_chunk(&session_id, body).await?;
-    state.storage.finalize_upload(&session_id, &digest).await?;
+    let finalize_result = state.storage.finalize_upload(&session_id, &digest).await;
     state.close_session(&session_id).await;
+    finalize_result?;
 
     let location = format!("/v2/{name}/blobs/{digest}");
     Ok(Response::builder()
@@ -222,17 +236,24 @@ pub async fn get_blob_status_handler(
     State(state): State<Arc<AppState>>,
     Path((name, session_id)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, AppError> {
+    let session_lock = state
+        .get_session_lock(&session_id)
+        .await
+        .ok_or_else(|| OciError::BlobUploadUnknown(session_id.clone()))?;
+    let _session_guard = session_lock.lock().await;
+
     if let Some(session) = state.get_session(&session_id).await {
         let location = format!("/v2/{name}/blobs/uploads/{session_id}");
-        let end_of_range = session.uploaded.saturating_sub(1);
+        let range = upload_range_header(session.uploaded);
 
-        Ok(Response::builder()
+        let mut builder = Response::builder()
             .status(StatusCode::NO_CONTENT)
             .header(LOCATION, location)
-            .header(RANGE, format!("0-{end_of_range}"))
-            .header("Docker-Upload-UUID", &session_id)
-            .body(Body::empty())
-            .unwrap())
+            .header("Docker-Upload-UUID", &session_id);
+        if let Some(range) = range {
+            builder = builder.header(RANGE, range);
+        }
+        Ok(builder.body(Body::empty()).unwrap())
     } else {
         Err(OciError::BlobUploadUnknown(session_id).into())
     }
@@ -307,4 +328,12 @@ fn parse_content_range(headers: &HeaderMap) -> Result<(u64, u64), AppError> {
         OciError::SizeInvalid("Content-Length or Content-Range header is required".to_string())
             .into(),
     )
+}
+
+fn upload_range_header(uploaded: u64) -> Option<String> {
+    if uploaded == 0 {
+        None
+    } else {
+        Some(format!("0-{}", uploaded - 1))
+    }
 }

--- a/project/distribution/src/storage/driver/filesystem.rs
+++ b/project/distribution/src/storage/driver/filesystem.rs
@@ -29,6 +29,15 @@ impl FilesystemStorage {
         }
         Ok(file_path)
     }
+
+    async fn cleanup_upload_dir(&self, session_id: &str) {
+        let upload_path = self.path_manager.upload_path(session_id);
+        if let Err(error) = remove_dir_all(&upload_path).await
+            && error.kind() != io::ErrorKind::NotFound
+        {
+            tracing::warn!("failed to clean up upload dir {upload_path}: {error}");
+        }
+    }
 }
 
 type Result<T> = std::result::Result<T, AppError>;
@@ -91,17 +100,28 @@ impl Storage for FilesystemStorage {
         let body_with_io_error = stream.map_err(io::Error::other);
         let mut body_reader = StreamReader::new(body_with_io_error);
 
-        let file_path = self
-            .ensure_parent_dir(&self.path_manager.blob_data_path(digest))
-            .await?;
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let upload_data_path = self.path_manager.upload_data_path(&session_id);
+        let file_path = self.ensure_parent_dir(&upload_data_path).await?;
 
         let file = File::create(file_path).await.map_to_internal()?;
         let mut file_writer = BufWriter::new(file);
 
-        let size = io::copy(&mut body_reader, &mut file_writer)
-            .await
-            .map_to_internal()?;
-        file_writer.shutdown().await.map_to_internal()?;
+        let size = match io::copy(&mut body_reader, &mut file_writer).await {
+            Ok(size) => size,
+            Err(error) => {
+                drop(file_writer.into_inner());
+                self.cleanup_upload_dir(&session_id).await;
+                return Err(InternalError::from(error).into());
+            }
+        };
+        if let Err(error) = file_writer.shutdown().await {
+            drop(file_writer.into_inner());
+            self.cleanup_upload_dir(&session_id).await;
+            return Err(InternalError::from(error).into());
+        }
+
+        self.finalize_upload(&session_id, digest).await?;
 
         Ok(size)
     }
@@ -120,13 +140,25 @@ impl Storage for FilesystemStorage {
             .open(file_path)
             .await
             .map_to_internal()?;
+        // Preserve chunks accepted before this PATCH; only roll back bytes
+        // appended by the current request if its body stream fails.
+        let original_len = file.metadata().await.map_to_internal()?.len();
 
         let mut file_writer = BufWriter::new(file);
 
-        let size = io::copy(&mut body_reader, &mut file_writer)
-            .await
-            .map_to_internal()?;
-        file_writer.shutdown().await.map_to_internal()?;
+        let size = match io::copy(&mut body_reader, &mut file_writer).await {
+            Ok(size) => size,
+            Err(error) => {
+                let file = file_writer.into_inner();
+                file.set_len(original_len).await.map_to_internal()?;
+                return Err(InternalError::from(error).into());
+            }
+        };
+        if let Err(error) = file_writer.shutdown().await {
+            let file = file_writer.into_inner();
+            file.set_len(original_len).await.map_to_internal()?;
+            return Err(InternalError::from(error).into());
+        }
 
         Ok(size)
     }
@@ -135,27 +167,34 @@ impl Storage for FilesystemStorage {
         let upload_data_path = self.path_manager.upload_data_path(session_id);
         let blob_data_path = self.path_manager.blob_data_path(digest);
 
-        verify_file_digest(&upload_data_path, digest).await?;
+        let result = async {
+            verify_file_digest(&upload_data_path, digest).await?;
 
-        self.ensure_parent_dir(&blob_data_path).await?;
+            self.ensure_parent_dir(&blob_data_path).await?;
 
-        const EXDEV: i32 = 18;
-        if let Err(e) = tokio::fs::rename(&upload_data_path, &blob_data_path).await {
-            if e.raw_os_error() == Some(EXDEV) {
-                tracing::warn!(
-                    "rename across mount points (EXDEV), falling back to copy+delete: {} -> {}",
-                    upload_data_path,
-                    blob_data_path
-                );
-                tokio::fs::copy(&upload_data_path, &blob_data_path)
-                    .await
-                    .map_to_internal()?;
-                tokio::fs::remove_file(&upload_data_path).await.ok();
-            } else {
-                return Err(InternalError::from(e).into());
+            const EXDEV: i32 = 18;
+            if let Err(e) = tokio::fs::rename(&upload_data_path, &blob_data_path).await {
+                if e.raw_os_error() == Some(EXDEV) {
+                    tracing::warn!(
+                        "rename across mount points (EXDEV), falling back to copy+delete: {} -> {}",
+                        upload_data_path,
+                        blob_data_path
+                    );
+                    tokio::fs::copy(&upload_data_path, &blob_data_path)
+                        .await
+                        .map_to_internal()?;
+                    tokio::fs::remove_file(&upload_data_path).await.ok();
+                } else {
+                    return Err(InternalError::from(e).into());
+                }
             }
+
+            Ok(())
         }
-        Ok(())
+        .await;
+
+        self.cleanup_upload_dir(session_id).await;
+        result
     }
 
     async fn put_tag(&self, name: &str, tag: &str, digest: &Digest) -> Result<()> {

--- a/project/distribution/src/storage/driver/s3.rs
+++ b/project/distribution/src/storage/driver/s3.rs
@@ -263,17 +263,21 @@ impl Storage for S3Storage {
 
         let file = File::create(&temp_path).await.map_to_internal()?;
         let mut file_writer = BufWriter::new(file);
-        let size = io::copy(&mut body_reader, &mut file_writer)
-            .await
-            .map_to_internal()?;
-        file_writer.shutdown().await.map_to_internal()?;
+        let size = match io::copy(&mut body_reader, &mut file_writer).await {
+            Ok(size) => size,
+            Err(error) => {
+                drop(file_writer.into_inner());
+                self.cleanup_temp_files(&session_id, &temp_path).await;
+                return Err(InternalError::from(error).into());
+            }
+        };
+        if let Err(error) = file_writer.shutdown().await {
+            drop(file_writer.into_inner());
+            self.cleanup_temp_files(&session_id, &temp_path).await;
+            return Err(InternalError::from(error).into());
+        }
 
-        let key = self.path_manager.blob_data_path(digest);
-        let s3_path = self.to_object_path(&key);
-
-        let result = self.do_finalize_upload(&temp_path, &s3_path).await;
-        self.cleanup_temp_files(&session_id, &temp_path).await;
-        result?;
+        self.finalize_upload(&session_id, digest).await?;
 
         Ok(size)
     }
@@ -295,13 +299,25 @@ impl Storage for S3Storage {
             .open(&temp_path)
             .await
             .map_to_internal()?;
+        // Preserve chunks accepted before this PATCH; only roll back bytes
+        // appended by the current request if its body stream fails.
+        let original_len = file.metadata().await.map_to_internal()?.len();
 
         let mut file_writer = BufWriter::new(file);
 
-        let size = io::copy(&mut body_reader, &mut file_writer)
-            .await
-            .map_to_internal()?;
-        file_writer.shutdown().await.map_to_internal()?;
+        let size = match io::copy(&mut body_reader, &mut file_writer).await {
+            Ok(size) => size,
+            Err(error) => {
+                let file = file_writer.into_inner();
+                file.set_len(original_len).await.map_to_internal()?;
+                return Err(InternalError::from(error).into());
+            }
+        };
+        if let Err(error) = file_writer.shutdown().await {
+            let file = file_writer.into_inner();
+            file.set_len(original_len).await.map_to_internal()?;
+            return Err(InternalError::from(error).into());
+        }
 
         Ok(size)
     }

--- a/project/distribution/src/utils/state.rs
+++ b/project/distribution/src/utils/state.rs
@@ -7,11 +7,12 @@ use crate::storage::driver::s3::S3Storage;
 use anyhow::{Context, bail};
 use sqlx::PgPool;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[derive(Clone, Debug)]
 pub struct UploadSession {
     pub uploaded: u64,
+    pub operation_lock: Arc<Mutex<()>>,
 }
 
 #[derive(Clone)]
@@ -57,10 +58,23 @@ impl AppState {
         sessions.get(id).cloned()
     }
 
+    pub async fn get_session_lock(&self, id: &str) -> Option<Arc<Mutex<()>>> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(id)
+            .map(|session| session.operation_lock.clone())
+    }
+
     pub async fn create_session(&self) -> String {
         let mut sessions = self.sessions.write().await;
         let session_id = uuid::Uuid::new_v4().to_string();
-        sessions.insert(session_id.clone(), UploadSession { uploaded: 0 });
+        sessions.insert(
+            session_id.clone(),
+            UploadSession {
+                uploaded: 0,
+                operation_lock: Arc::new(Mutex::new(())),
+            },
+        );
         session_id
     }
 

--- a/project/rkforge/src/push/mod.rs
+++ b/project/rkforge/src/push/mod.rs
@@ -8,7 +8,7 @@ use crate::registry::{
 };
 use crate::rt::block_on;
 use crate::storage::{DigestExt, parse_image_ref};
-use anyhow::{Context, bail};
+use anyhow::{Context, anyhow, bail};
 use clap::Parser;
 use futures::{StreamExt, TryStreamExt, stream};
 use oci_client::Client;
@@ -16,10 +16,12 @@ use oci_client::client::PushResponse;
 use oci_client::manifest::{OciImageIndex, OciManifest};
 use oci_client::secrets::RegistryAuth;
 use oci_spec::distribution::Reference;
+use reqwest::header::RANGE;
 use reqwest::{StatusCode, Url};
 use std::collections::HashMap;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
 
@@ -130,10 +132,30 @@ enum BlobUploadStrategy {
     Chunked,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RemoteBlobStatus {
+    Exists,
+    Missing,
+    Unknown,
+}
+
+enum PatchChunkOutcome {
+    Accepted(Url),
+    NeedsReconcile,
+}
+
+struct UploadStatus {
+    location: Url,
+    uploaded: u64,
+}
+
 const SMALL_BLOB_UPLOAD_THRESHOLD_BYTES: u64 = 16 * 1024 * 1024;
 const CHUNKED_BLOB_UPLOAD_SIZE_BYTES: usize = 32 * 1024 * 1024;
 const MAX_CONCURRENT_BLOB_UPLOADS: usize = 4;
 const STREAM_READ_BUFFER_BYTES: usize = 1024 * 1024;
+const BLOB_UPLOAD_MAX_ATTEMPTS: usize = 5;
+const BLOB_UPLOAD_RETRY_BASE_DELAY_MS: u64 = 300;
+const BLOB_UPLOAD_RETRY_MAX_DELAY_MS: u64 = 5_000;
 
 fn blob_upload_strategy(size: u64) -> BlobUploadStrategy {
     if size <= SMALL_BLOB_UPLOAD_THRESHOLD_BYTES {
@@ -141,6 +163,44 @@ fn blob_upload_strategy(size: u64) -> BlobUploadStrategy {
     } else {
         BlobUploadStrategy::Chunked
     }
+}
+
+fn retry_delay(attempt: usize) -> Duration {
+    let shift = attempt.saturating_sub(1).min(16) as u32;
+    let multiplier = 1_u64 << shift;
+    Duration::from_millis(
+        (BLOB_UPLOAD_RETRY_BASE_DELAY_MS * multiplier).min(BLOB_UPLOAD_RETRY_MAX_DELAY_MS),
+    )
+}
+
+fn should_retry_status(status: StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+        )
+}
+
+fn should_retry_reqwest_error(error: &reqwest::Error) -> bool {
+    !error.is_builder() && !error.is_status()
+}
+
+fn parse_uploaded_from_range(range: Option<&reqwest::header::HeaderValue>) -> anyhow::Result<u64> {
+    let Some(range) = range else {
+        return Ok(0);
+    };
+    let range = range
+        .to_str()
+        .context("registry Range header is not valid UTF-8")?;
+    let range = range.strip_prefix("bytes=").unwrap_or(range);
+    let (_, end) = range
+        .split_once('-')
+        .ok_or_else(|| anyhow!("registry Range header has invalid format: {range}"))?;
+    let end = end
+        .parse::<u64>()
+        .with_context(|| format!("registry Range header has invalid end offset: {range}"))?;
+
+    Ok(end + 1)
 }
 
 impl BlobUploader {
@@ -207,52 +267,7 @@ impl BlobUploader {
         }
     }
 
-    async fn begin_upload(&self, target_ref: &Reference) -> anyhow::Result<Url> {
-        let url = self.uploads_url(target_ref);
-        let response = self
-            .apply_auth(self.http.post(&url))
-            .header("Content-Length", 0)
-            .send()
-            .await
-            .with_context(|| {
-                format!("failed to begin upload session for {}", target_ref.whole())
-            })?;
-
-        self.extract_location(response, StatusCode::ACCEPTED)
-            .await
-            .with_context(|| format!("failed to open upload session for {}", target_ref.whole()))
-    }
-
-    async fn blob_exists(&self, target_ref: &Reference, digest: &str) -> anyhow::Result<bool> {
-        let response = self
-            .apply_auth(self.http.head(self.blob_url(target_ref, digest)))
-            .send()
-            .await
-            .with_context(|| format!("failed to check remote blob {digest}"))?;
-
-        match response.status() {
-            StatusCode::OK => Ok(true),
-            StatusCode::NOT_FOUND => Ok(false),
-            status => {
-                let url = response.url().to_string();
-                let body = response.text().await.unwrap_or_default();
-                bail!("registry returned {status} for {url}: {body}");
-            }
-        }
-    }
-
-    async fn extract_location(
-        &self,
-        response: reqwest::Response,
-        expected_status: StatusCode,
-    ) -> anyhow::Result<Url> {
-        if response.status() != expected_status {
-            let status = response.status();
-            let url = response.url().to_string();
-            let body = response.text().await.unwrap_or_default();
-            bail!("registry returned {status} for {url}: {body}");
-        }
-
+    fn extract_location_header(&self, response: &reqwest::Response) -> anyhow::Result<Url> {
         let location = response
             .headers()
             .get("Location")
@@ -262,13 +277,114 @@ impl BlobUploader {
         self.location_header_to_url(location)
     }
 
+    async fn status_error(
+        response: reqwest::Response,
+        expected_status: StatusCode,
+    ) -> anyhow::Error {
+        let status = response.status();
+        let url = response.url().to_string();
+        let body = response.text().await.unwrap_or_default();
+        anyhow!("registry returned {status} for {url}, expected {expected_status}: {body}")
+    }
+
+    async fn send_with_retries(
+        &self,
+        operation: &str,
+        expected_status: StatusCode,
+        mut build_request: impl FnMut() -> reqwest::RequestBuilder,
+    ) -> anyhow::Result<reqwest::Response> {
+        for attempt in 1..=BLOB_UPLOAD_MAX_ATTEMPTS {
+            match build_request().send().await {
+                Ok(response) if response.status() == expected_status => return Ok(response),
+                Ok(response) if should_retry_status(response.status()) => {
+                    let error = Self::status_error(response, expected_status).await;
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error).with_context(|| format!("failed to {operation}"));
+                    }
+                }
+                Ok(response) => {
+                    return Err(Self::status_error(response, expected_status).await)
+                        .with_context(|| format!("failed to {operation}"));
+                }
+                Err(error) if should_retry_reqwest_error(&error) => {
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error).with_context(|| format!("failed to {operation}"));
+                    }
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| format!("failed to {operation}"));
+                }
+            }
+
+            tokio::time::sleep(retry_delay(attempt)).await;
+        }
+
+        unreachable!("retry loop always returns before exhausting attempts")
+    }
+
+    async fn begin_upload(&self, target_ref: &Reference) -> anyhow::Result<Url> {
+        let url = self.uploads_url(target_ref);
+        let response = self
+            .send_with_retries(
+                &format!("begin upload session for {}", target_ref.whole()),
+                StatusCode::ACCEPTED,
+                || {
+                    self.apply_auth(self.http.post(&url))
+                        .header("Content-Length", 0)
+                },
+            )
+            .await?;
+
+        self.extract_location_header(&response)
+            .with_context(|| format!("failed to open upload session for {}", target_ref.whole()))
+    }
+
+    async fn remote_blob_status(
+        &self,
+        target_ref: &Reference,
+        digest: &str,
+    ) -> anyhow::Result<RemoteBlobStatus> {
+        let response = match self
+            .apply_auth(self.http.head(self.blob_url(target_ref, digest)))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) if should_retry_reqwest_error(&error) => {
+                return Ok(RemoteBlobStatus::Unknown);
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to check remote blob {digest}"));
+            }
+        };
+
+        match response.status() {
+            StatusCode::OK => Ok(RemoteBlobStatus::Exists),
+            StatusCode::NOT_FOUND => Ok(RemoteBlobStatus::Missing),
+            _ => Ok(RemoteBlobStatus::Unknown),
+        }
+    }
+
+    async fn upload_status(&self, location: &Url) -> anyhow::Result<UploadStatus> {
+        let response = self
+            .send_with_retries("query upload status", StatusCode::NO_CONTENT, || {
+                self.apply_auth(self.http.get(location.clone()))
+            })
+            .await?;
+
+        Ok(UploadStatus {
+            location: self.extract_location_header(&response)?,
+            uploaded: parse_uploaded_from_range(response.headers().get(RANGE))?,
+        })
+    }
+
     async fn push_blob_from_path(
         &self,
         target_ref: &Reference,
         blob_path: &Path,
         digest: &str,
     ) -> anyhow::Result<String> {
-        if self.blob_exists(target_ref, digest).await? {
+        if self.remote_blob_status(target_ref, digest).await? == RemoteBlobStatus::Exists {
             return Ok(self.blob_url(target_ref, digest));
         }
 
@@ -296,31 +412,105 @@ impl BlobUploader {
         digest: &str,
         size: u64,
     ) -> anyhow::Result<String> {
-        let mut location = self.begin_upload(target_ref).await?;
-        location.query_pairs_mut().append_pair("digest", digest);
+        for attempt in 1..=BLOB_UPLOAD_MAX_ATTEMPTS {
+            let mut location = self.begin_upload(target_ref).await?;
+            location.query_pairs_mut().append_pair("digest", digest);
 
-        let file = tokio::fs::File::open(blob_path)
-            .await
-            .with_context(|| format!("failed to open {}", blob_path.display()))?;
-        let body =
-            reqwest::Body::wrap_stream(ReaderStream::with_capacity(file, STREAM_READ_BUFFER_BYTES));
+            let file = tokio::fs::File::open(blob_path)
+                .await
+                .with_context(|| format!("failed to open {}", blob_path.display()))?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::with_capacity(
+                file,
+                STREAM_READ_BUFFER_BYTES,
+            ));
 
-        let response = self
-            .apply_auth(self.http.put(location.clone()))
-            .header("Content-Length", size)
-            .header("Content-Type", "application/octet-stream")
-            .body(body)
-            .send()
-            .await
-            .with_context(|| format!("failed to upload {}", blob_path.display()))?;
+            let response = self
+                .apply_auth(self.http.put(location.clone()))
+                .header("Content-Length", size)
+                .header("Content-Type", "application/octet-stream")
+                .body(body)
+                .send()
+                .await;
 
-        Ok(self
-            .extract_location(response, StatusCode::CREATED)
-            .await?
-            .to_string())
+            match response {
+                Ok(response) if response.status() == StatusCode::CREATED => {
+                    return Ok(self.extract_location_header(&response)?.to_string());
+                }
+                Ok(response) if should_retry_status(response.status()) => {
+                    if self.remote_blob_status(target_ref, digest).await?
+                        == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    let error = Self::status_error(response, StatusCode::CREATED).await;
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error)
+                            .with_context(|| format!("failed to upload {}", blob_path.display()));
+                    }
+                }
+                Ok(response) => {
+                    return Err(Self::status_error(response, StatusCode::CREATED).await)
+                        .with_context(|| format!("failed to upload {}", blob_path.display()));
+                }
+                Err(error) if should_retry_reqwest_error(&error) => {
+                    if self.remote_blob_status(target_ref, digest).await?
+                        == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error)
+                            .with_context(|| format!("failed to upload {}", blob_path.display()));
+                    }
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to upload {}", blob_path.display()));
+                }
+            }
+
+            tokio::time::sleep(retry_delay(attempt)).await;
+        }
+
+        unreachable!("retry loop always returns before exhausting attempts")
     }
 
     async fn push_blob_chunked_from_path(
+        &self,
+        target_ref: &Reference,
+        blob_path: &Path,
+        digest: &str,
+        size: u64,
+    ) -> anyhow::Result<String> {
+        for attempt in 1..=BLOB_UPLOAD_MAX_ATTEMPTS {
+            match self
+                .push_blob_chunked_upload_session(target_ref, blob_path, digest, size)
+                .await
+            {
+                Ok(blob_url) => return Ok(blob_url),
+                Err(error) => {
+                    if self.remote_blob_status(target_ref, digest).await?
+                        == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error)
+                            .with_context(|| format!("failed to push chunked blob {digest}"));
+                    }
+
+                    tokio::time::sleep(retry_delay(attempt)).await;
+                }
+            }
+        }
+
+        unreachable!("retry loop always returns before exhausting attempts")
+    }
+
+    async fn push_blob_chunked_upload_session(
         &self,
         target_ref: &Reference,
         blob_path: &Path,
@@ -331,55 +521,202 @@ impl BlobUploader {
 
         let mut start: u64 = 0;
         while start < size {
-            let chunk_size = (size - start).min(CHUNKED_BLOB_UPLOAD_SIZE_BYTES as u64);
-            let end = start + chunk_size - 1;
-            let mut chunk_file = tokio::fs::File::open(blob_path)
-                .await
-                .with_context(|| format!("failed to open {}", blob_path.display()))?;
-            chunk_file
-                .seek(SeekFrom::Start(start))
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to seek {} to chunk offset {start}",
-                        blob_path.display()
-                    )
-                })?;
-            let body = reqwest::Body::wrap_stream(ReaderStream::with_capacity(
-                chunk_file.take(chunk_size),
-                STREAM_READ_BUFFER_BYTES,
-            ));
-
-            let response = self
-                .apply_auth(self.http.patch(location.clone()))
-                .header("Content-Range", format!("{start}-{end}"))
-                .header("Content-Length", chunk_size)
-                .header("Content-Type", "application/octet-stream")
-                .body(body)
-                .send()
-                .await
-                .with_context(|| format!("failed to upload chunk for {}", blob_path.display()))?;
-
-            location = self
-                .extract_location(response, StatusCode::ACCEPTED)
-                .await
-                .with_context(|| format!("failed to update upload session for {digest}"))?;
-            start = end + 1;
+            start = self
+                .push_blob_chunk_with_retries(&mut location, blob_path, digest, start, size)
+                .await?;
         }
 
-        let mut finalize_url = location;
-        finalize_url.query_pairs_mut().append_pair("digest", digest);
-        let response = self
-            .apply_auth(self.http.put(finalize_url))
-            .header("Content-Length", 0)
-            .send()
+        self.finalize_chunked_upload(target_ref, location, digest)
             .await
-            .with_context(|| format!("failed to finalize chunked upload for {digest}"))?;
+    }
 
-        Ok(self
-            .extract_location(response, StatusCode::CREATED)
-            .await?
-            .to_string())
+    async fn push_blob_chunk_with_retries(
+        &self,
+        location: &mut Url,
+        blob_path: &Path,
+        digest: &str,
+        start: u64,
+        size: u64,
+    ) -> anyhow::Result<u64> {
+        let mut current_start = start;
+
+        for attempt in 1..=BLOB_UPLOAD_MAX_ATTEMPTS {
+            let chunk_size = (size - current_start).min(CHUNKED_BLOB_UPLOAD_SIZE_BYTES as u64);
+            match self
+                .patch_blob_chunk(location.clone(), blob_path, current_start, chunk_size)
+                .await?
+            {
+                PatchChunkOutcome::Accepted(next_location) => {
+                    *location = next_location;
+                    return Ok(current_start + chunk_size);
+                }
+                PatchChunkOutcome::NeedsReconcile => {
+                    let status = self.upload_status(location).await.with_context(|| {
+                        format!("failed to reconcile upload session after chunk error for {digest}")
+                    })?;
+                    *location = status.location;
+
+                    if status.uploaded > size {
+                        bail!(
+                            "registry upload session for {digest} reported {} bytes, larger than blob size {size}",
+                            status.uploaded
+                        );
+                    }
+                    if status.uploaded < current_start {
+                        bail!(
+                            "registry upload session for {digest} moved backwards from {current_start} to {} bytes",
+                            status.uploaded
+                        );
+                    }
+                    if status.uploaded > current_start {
+                        return Ok(status.uploaded);
+                    }
+                }
+            }
+
+            if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                bail!(
+                    "failed to upload chunk for {} after {BLOB_UPLOAD_MAX_ATTEMPTS} attempts",
+                    blob_path.display()
+                );
+            }
+
+            tokio::time::sleep(retry_delay(attempt)).await;
+            current_start = start;
+        }
+
+        unreachable!("retry loop always returns before exhausting attempts")
+    }
+
+    async fn patch_blob_chunk(
+        &self,
+        location: Url,
+        blob_path: &Path,
+        start: u64,
+        chunk_size: u64,
+    ) -> anyhow::Result<PatchChunkOutcome> {
+        let end = start + chunk_size - 1;
+        let mut chunk_file = tokio::fs::File::open(blob_path)
+            .await
+            .with_context(|| format!("failed to open {}", blob_path.display()))?;
+        chunk_file
+            .seek(SeekFrom::Start(start))
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to seek {} to chunk offset {start}",
+                    blob_path.display()
+                )
+            })?;
+        let body = reqwest::Body::wrap_stream(ReaderStream::with_capacity(
+            chunk_file.take(chunk_size),
+            STREAM_READ_BUFFER_BYTES,
+        ));
+
+        let response = self
+            .apply_auth(self.http.patch(location))
+            .header("Content-Range", format!("{start}-{end}"))
+            .header("Content-Length", chunk_size)
+            .header("Content-Type", "application/octet-stream")
+            .body(body)
+            .send()
+            .await;
+
+        let response = match response {
+            Ok(response) => response,
+            Err(error) if should_retry_reqwest_error(&error) => {
+                return Ok(PatchChunkOutcome::NeedsReconcile);
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to upload chunk for {}", blob_path.display())
+                });
+            }
+        };
+
+        match response.status() {
+            StatusCode::ACCEPTED => Ok(PatchChunkOutcome::Accepted(
+                self.extract_location_header(&response)?,
+            )),
+            StatusCode::RANGE_NOT_SATISFIABLE => Ok(PatchChunkOutcome::NeedsReconcile),
+            status if should_retry_status(status) => Ok(PatchChunkOutcome::NeedsReconcile),
+            _ => Err(Self::status_error(response, StatusCode::ACCEPTED)
+                .await
+                .context("failed to update upload session")),
+        }
+    }
+
+    async fn finalize_chunked_upload(
+        &self,
+        target_ref: &Reference,
+        location: Url,
+        digest: &str,
+    ) -> anyhow::Result<String> {
+        for attempt in 1..=BLOB_UPLOAD_MAX_ATTEMPTS {
+            let mut finalize_url = location.clone();
+            finalize_url.query_pairs_mut().append_pair("digest", digest);
+
+            let response = self
+                .apply_auth(self.http.put(finalize_url))
+                .header("Content-Length", 0)
+                .send()
+                .await;
+
+            match response {
+                Ok(response) if response.status() == StatusCode::CREATED => {
+                    return Ok(self.extract_location_header(&response)?.to_string());
+                }
+                Ok(response) if should_retry_status(response.status()) => {
+                    if self.remote_blob_status(target_ref, digest).await?
+                        == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    let error = Self::status_error(response, StatusCode::CREATED).await;
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error).with_context(|| {
+                            format!("failed to finalize chunked upload for {digest}")
+                        });
+                    }
+                }
+                Ok(response) => {
+                    if response.status() == StatusCode::NOT_FOUND
+                        && self.remote_blob_status(target_ref, digest).await?
+                            == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    return Err(Self::status_error(response, StatusCode::CREATED).await)
+                        .with_context(|| {
+                            format!("failed to finalize chunked upload for {digest}")
+                        });
+                }
+                Err(error) if should_retry_reqwest_error(&error) => {
+                    if self.remote_blob_status(target_ref, digest).await?
+                        == RemoteBlobStatus::Exists
+                    {
+                        return Ok(self.blob_url(target_ref, digest));
+                    }
+
+                    if attempt == BLOB_UPLOAD_MAX_ATTEMPTS {
+                        return Err(error).with_context(|| {
+                            format!("failed to finalize chunked upload for {digest}")
+                        });
+                    }
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to finalize chunked upload for {digest}")
+                    });
+                }
+            }
+
+            tokio::time::sleep(retry_delay(attempt)).await;
+        }
+
+        unreachable!("retry loop always returns before exhausting attempts")
     }
 }
 
@@ -595,10 +932,11 @@ fn strip_explicit_tag(raw: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use crate::storage::parse_image_ref;
+    use reqwest::header::HeaderValue;
 
     use super::{
         BlobUploadStrategy, blob_upload_strategy, has_explicit_registry, has_explicit_tag,
-        should_include_digest, strip_explicit_tag,
+        parse_uploaded_from_range, should_include_digest, strip_explicit_tag,
     };
 
     #[test]
@@ -687,6 +1025,23 @@ mod tests {
         assert_eq!(
             blob_upload_strategy(3 * 1024 * 1024 * 1024),
             BlobUploadStrategy::Chunked
+        );
+    }
+
+    #[test]
+    fn test_parse_uploaded_from_range() {
+        assert_eq!(parse_uploaded_from_range(None).unwrap(), 0);
+        assert_eq!(
+            parse_uploaded_from_range(Some(&HeaderValue::from_static("0-0"))).unwrap(),
+            1
+        );
+        assert_eq!(
+            parse_uploaded_from_range(Some(&HeaderValue::from_static("0-33554431"))).unwrap(),
+            32 * 1024 * 1024
+        );
+        assert_eq!(
+            parse_uploaded_from_range(Some(&HeaderValue::from_static("bytes=0-33554431"))).unwrap(),
+            32 * 1024 * 1024
         );
     }
 }


### PR DESCRIPTION
Add a custom rkforge blob push path with streamed monolithic uploads,
chunked large-blob uploads, retry/backoff, and upload-status reconciliation
so transient network failures can resume instead of failing the whole push.

Serialize distribution upload operations per upload session to prevent
overlapping PATCH retries from appending the same chunk twice. Make upload
Range handling unambiguous for empty sessions and parse inclusive ranges
correctly on the client.

Make filesystem and S3 storage write blobs through temporary upload files,
verify digests before publishing, roll back failed chunk writes, and clean up
upload sessions/temp files on finalize success or failure.

Sync Cargo.lock after the push dependency changes.