### PR TITLE
feat(registry): support resumable blob pulls

### DIFF
--- a/project/distribution/src/api/v2.rs
+++ b/project/distribution/src/api/v2.rs
@@ -93,9 +93,11 @@ async fn dispatch_handler(
             let name = name.join("/");
             match *method {
                 // Pull blobs
-                Method::GET => get_blob_handler(State(state), Path((name, digest.to_string())))
-                    .await
-                    .map(|res| res.into_response()),
+                Method::GET => {
+                    get_blob_handler(State(state), Path((name, digest.to_string())), headers)
+                        .await
+                        .map(|res| res.into_response())
+                }
                 // Check if blob exists in the registry
                 Method::HEAD => head_blob_handler(State(state), Path((name, digest.to_string())))
                     .await

--- a/project/distribution/src/service/blob.rs
+++ b/project/distribution/src/service/blob.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 pub async fn get_blob_handler(
     State(state): State<Arc<AppState>>,
     Path((name, digest_str)): Path<(String, String)>,
-) -> Result<impl IntoResponse, AppError> {
+    headers: HeaderMap,
+) -> Result<Response<Body>, AppError> {
     if !is_valid_name(&name) {
         return Err(OciError::NameInvalid(name).into());
     }
@@ -24,13 +25,42 @@ pub async fn get_blob_handler(
     let digest = oci_digest::from_str(&digest_str)
         .map_err(|_| OciError::DigestInvalid(digest_str.clone()))?;
 
-    let obj = state.storage.get_blob(&digest).await?;
+    let total_size = state.storage.blob_size(&digest).await?;
+    let range = match parse_blob_range(&headers, total_size) {
+        BlobRangeRequest::None => {
+            let obj = state.storage.get_blob(&digest).await?;
+            let body = Body::from_stream(obj.stream);
+
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/octet-stream")
+                .header(header::CONTENT_LENGTH, obj.size)
+                .header("Accept-Ranges", "bytes")
+                .header("Docker-Content-Digest", digest_str)
+                .body(body)
+                .unwrap());
+        }
+        BlobRangeRequest::Satisfiable(range) => range,
+        BlobRangeRequest::Unsatisfiable => {
+            return Ok(range_not_satisfiable_response(total_size));
+        }
+    };
+
+    let obj = state
+        .storage
+        .get_blob_range(&digest, range.start..range.end + 1)
+        .await?;
     let body = Body::from_stream(obj.stream);
 
     Ok(Response::builder()
-        .status(StatusCode::OK)
+        .status(StatusCode::PARTIAL_CONTENT)
         .header(header::CONTENT_TYPE, "application/octet-stream")
         .header(header::CONTENT_LENGTH, obj.size)
+        .header(
+            header::CONTENT_RANGE,
+            format!("bytes {}-{}/{}", range.start, range.end, range.total),
+        )
+        .header("Accept-Ranges", "bytes")
         .header("Docker-Content-Digest", digest_str)
         .body(body)
         .unwrap())
@@ -53,6 +83,7 @@ pub async fn head_blob_handler(
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "application/octet-stream")
         .header(header::CONTENT_LENGTH, content_length)
+        .header("Accept-Ranges", "bytes")
         .header("Docker-Content-Digest", digest_str)
         .body(Body::empty())
         .unwrap())
@@ -330,10 +361,164 @@ fn parse_content_range(headers: &HeaderMap) -> Result<(u64, u64), AppError> {
     )
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum BlobRangeRequest {
+    None,
+    Satisfiable(BlobRange),
+    Unsatisfiable,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BlobRange {
+    start: u64,
+    end: u64,
+    total: u64,
+}
+
+fn parse_blob_range(headers: &HeaderMap, total_size: u64) -> BlobRangeRequest {
+    let Some(header_value) = headers.get(RANGE) else {
+        return BlobRangeRequest::None;
+    };
+    let Ok(header_value) = header_value.to_str() else {
+        return BlobRangeRequest::Unsatisfiable;
+    };
+    let Some((unit, range_spec)) = header_value.trim().split_once('=') else {
+        return BlobRangeRequest::Unsatisfiable;
+    };
+    if !unit.eq_ignore_ascii_case("bytes") || range_spec.contains(',') {
+        return BlobRangeRequest::Unsatisfiable;
+    }
+
+    let Some((start_spec, end_spec)) = range_spec.split_once('-') else {
+        return BlobRangeRequest::Unsatisfiable;
+    };
+    let start_spec = start_spec.trim();
+    let end_spec = end_spec.trim();
+
+    if start_spec.is_empty() {
+        return parse_blob_suffix_range(end_spec, total_size);
+    }
+
+    let Ok(start) = start_spec.parse::<u64>() else {
+        return BlobRangeRequest::Unsatisfiable;
+    };
+    if start >= total_size {
+        return BlobRangeRequest::Unsatisfiable;
+    }
+
+    let end = if end_spec.is_empty() {
+        total_size - 1
+    } else {
+        let Ok(requested_end) = end_spec.parse::<u64>() else {
+            return BlobRangeRequest::Unsatisfiable;
+        };
+        if requested_end < start {
+            return BlobRangeRequest::Unsatisfiable;
+        }
+        requested_end.min(total_size - 1)
+    };
+
+    BlobRangeRequest::Satisfiable(BlobRange {
+        start,
+        end,
+        total: total_size,
+    })
+}
+
+fn parse_blob_suffix_range(end_spec: &str, total_size: u64) -> BlobRangeRequest {
+    let Ok(suffix_len) = end_spec.parse::<u64>() else {
+        return BlobRangeRequest::Unsatisfiable;
+    };
+    if suffix_len == 0 || total_size == 0 {
+        return BlobRangeRequest::Unsatisfiable;
+    }
+
+    let start = total_size.saturating_sub(suffix_len);
+    BlobRangeRequest::Satisfiable(BlobRange {
+        start,
+        end: total_size - 1,
+        total: total_size,
+    })
+}
+
+fn range_not_satisfiable_response(total_size: u64) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+        .header(header::CONTENT_RANGE, format!("bytes */{total_size}"))
+        .header("Accept-Ranges", "bytes")
+        .body(Body::empty())
+        .unwrap()
+}
+
 fn upload_range_header(uploaded: u64) -> Option<String> {
     if uploaded == 0 {
         None
     } else {
         Some(format!("0-{}", uploaded - 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, header};
+
+    use super::{BlobRange, BlobRangeRequest, parse_blob_range};
+
+    fn range_headers(range: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RANGE, range.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn parse_blob_range_returns_none_without_header() {
+        assert_eq!(
+            parse_blob_range(&HeaderMap::new(), 10),
+            BlobRangeRequest::None
+        );
+    }
+
+    #[test]
+    fn parse_blob_range_supports_open_ended_range() {
+        assert_eq!(
+            parse_blob_range(&range_headers("bytes=5-"), 10),
+            BlobRangeRequest::Satisfiable(BlobRange {
+                start: 5,
+                end: 9,
+                total: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_blob_range_caps_end_at_total_size() {
+        assert_eq!(
+            parse_blob_range(&range_headers("bytes=5-99"), 10),
+            BlobRangeRequest::Satisfiable(BlobRange {
+                start: 5,
+                end: 9,
+                total: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_blob_range_supports_suffix_range() {
+        assert_eq!(
+            parse_blob_range(&range_headers("bytes=-4"), 10),
+            BlobRangeRequest::Satisfiable(BlobRange {
+                start: 6,
+                end: 9,
+                total: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_blob_range_rejects_unsatisfiable_range() {
+        assert_eq!(
+            parse_blob_range(&range_headers("bytes=10-"), 10),
+            BlobRangeRequest::Unsatisfiable
+        );
     }
 }

--- a/project/distribution/src/storage/driver/filesystem.rs
+++ b/project/distribution/src/storage/driver/filesystem.rs
@@ -7,8 +7,9 @@ use crate::storage::{ObjectStream, Storage, StorageObject, verify_file_digest};
 use axum::body::BodyDataStream;
 use futures::TryStreamExt;
 use oci_spec::image::Digest;
+use std::io::SeekFrom;
 use tokio::fs::{File, OpenOptions, create_dir_all, read_dir, remove_dir_all};
-use tokio::io::{self, AsyncWriteExt, BufWriter};
+use tokio::io::{self, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter};
 use tokio_util::io::{ReaderStream, StreamReader};
 
 pub struct FilesystemStorage {
@@ -57,6 +58,31 @@ impl Storage for FilesystemStorage {
 
         let size = file.metadata().await.map_to_internal()?.len();
         let stream: ObjectStream = Box::pin(ReaderStream::new(file));
+
+        Ok(StorageObject { stream, size })
+    }
+
+    async fn get_blob_range(
+        &self,
+        digest: &Digest,
+        range: std::ops::Range<u64>,
+    ) -> Result<StorageObject> {
+        let path = self.path_manager.blob_data_path(digest);
+
+        let mut file = match File::open(&path).await {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(OciError::BlobUnknown(digest.to_string()).into());
+            }
+            Err(e) => return Err(InternalError::from(e).into()),
+        };
+
+        file.seek(SeekFrom::Start(range.start))
+            .await
+            .map_to_internal()?;
+
+        let size = range.end.saturating_sub(range.start);
+        let stream: ObjectStream = Box::pin(ReaderStream::new(file.take(size)));
 
         Ok(StorageObject { stream, size })
     }

--- a/project/distribution/src/storage/driver/s3.rs
+++ b/project/distribution/src/storage/driver/s3.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures::TryStreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjectPath;
-use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
 use oci_spec::image::Digest;
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{self, AsyncWriteExt, BufWriter};
@@ -198,6 +198,34 @@ impl Storage for S3Storage {
         })?;
 
         let size = result.meta.size;
+        let stream: ObjectStream = Box::pin(result.into_stream().map_err(std::io::Error::other));
+
+        Ok(StorageObject { stream, size })
+    }
+
+    async fn get_blob_range(
+        &self,
+        digest: &Digest,
+        range: std::ops::Range<u64>,
+    ) -> Result<StorageObject> {
+        let key = self.path_manager.blob_data_path(digest);
+        let path = self.to_object_path(&key);
+        let options = GetOptions::new().with_range(Some(GetRange::Bounded(range)));
+
+        let result = self
+            .store
+            .get_opts(&path, options)
+            .await
+            .map_err(|e| match e {
+                object_store::Error::NotFound { .. } => {
+                    AppError::Oci(OciError::BlobUnknown(digest.to_string()))
+                }
+                other => {
+                    AppError::Internal(InternalError::Others(format!("S3 get error: {other}")))
+                }
+            })?;
+
+        let size = result.range.end.saturating_sub(result.range.start);
         let stream: ObjectStream = Box::pin(result.into_stream().map_err(std::io::Error::other));
 
         Ok(StorageObject { stream, size })

--- a/project/distribution/src/storage/mod.rs
+++ b/project/distribution/src/storage/mod.rs
@@ -84,6 +84,12 @@ pub async fn verify_file_digest(path: &str, expected: &Digest) -> Result<()> {
 pub trait Storage: Send + Sync {
     async fn get_blob(&self, digest: &Digest) -> Result<StorageObject>;
 
+    async fn get_blob_range(
+        &self,
+        digest: &Digest,
+        range: std::ops::Range<u64>,
+    ) -> Result<StorageObject>;
+
     async fn blob_exists(&self, digest: &Digest) -> Result<bool>;
 
     async fn blob_size(&self, digest: &Digest) -> Result<u64>;

--- a/project/rkforge/src/pull/layer.rs
+++ b/project/rkforge/src/pull/layer.rs
@@ -1,16 +1,25 @@
-use crate::pull::downloader::LayerDownloadWrapper;
 use crate::pull::media::get_media_type;
 use crate::storage::{DigestExt, ultimate_blob_path};
-use anyhow::Context;
+use anyhow::{Context, bail};
+use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use iterator_ext::IteratorExt;
 use oci_client::Client;
+use oci_client::client::BlobResponse;
 use oci_client::manifest::{OciDescriptor, OciImageManifest};
 use oci_spec::distribution::Reference;
+use sha2::{Digest, Sha256};
 use std::iter;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 use tempfile::TempDir;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+
+const DEFAULT_PULL_CONCURRENCY: usize = 3;
+const DEFAULT_PULL_RETRIES: usize = 3;
 
 pub async fn pull_layers(
     client: &Client,
@@ -19,6 +28,10 @@ pub async fn pull_layers(
     no_cache: bool,
     quiet: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
+    if !no_cache {
+        remove_invalid_cached_layer_blobs(manifest).await?;
+    }
+
     let to_download = manifest
         .layers
         .iter()
@@ -26,25 +39,113 @@ pub async fn pull_layers(
         .map(Ok)
         .try_filter(|layer| Ok(no_cache || !ultimate_blob_path(&layer.digest)?.exists()))
         .collect::<anyhow::Result<Vec<_>>>()?;
+    let new_blob_paths = to_download
+        .iter()
+        .map(|descriptor| ultimate_blob_path(&descriptor.digest))
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let tasks = to_download.into_iter().map(|descriptor| {
-        let client = client.clone();
-        let image_ref = image_ref.clone();
-        let descriptor = descriptor.clone();
+    let semaphore = Arc::new(Semaphore::new(pull_concurrency_limit()));
+    let tasks = to_download
+        .into_iter()
+        .map(|descriptor| {
+            let client = client.clone();
+            let image_ref = image_ref.clone();
+            let descriptor = descriptor.clone();
+            let semaphore = semaphore.clone();
 
-        tokio::spawn(async move {
-            pull_and_unpack_layer(&client, &image_ref, &descriptor, no_cache, quiet).await
+            tokio::spawn(async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .with_context(|| "Failed to acquire layer pull permit")?;
+                pull_and_unpack_layer(&client, &image_ref, &descriptor, no_cache, quiet).await
+            })
         })
-    });
+        .collect::<Vec<_>>();
 
-    futures::future::try_join_all(tasks).await?;
+    if let Err(err) = wait_for_layer_tasks(tasks).await {
+        if let Err(cleanup_err) = remove_cached_blobs(&new_blob_paths).await {
+            tracing::warn!(
+                error = ?cleanup_err,
+                "failed to remove blobs created by failed image pull"
+            );
+        }
+        return Err(err);
+    }
 
     let layers = manifest
         .layers
         .iter()
         .map(|layer| ultimate_blob_path(&layer.digest))
         .collect::<anyhow::Result<Vec<_>>>()?;
+    ensure_unpacked_layer_dirs(&layers).await?;
     Ok(layers)
+}
+
+async fn remove_invalid_cached_layer_blobs(manifest: &OciImageManifest) -> anyhow::Result<()> {
+    for layer in &manifest.layers {
+        let path = ultimate_blob_path(&layer.digest)?;
+        let metadata = match tokio::fs::metadata(&path).await {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to stat cached layer {}", path.display()));
+            }
+        };
+        if !metadata.is_dir() {
+            remove_cached_blob(&path).await?;
+        }
+    }
+    Ok(())
+}
+
+fn pull_concurrency_limit() -> usize {
+    parse_positive_env_usize("RKFORGE_PULL_CONCURRENCY", DEFAULT_PULL_CONCURRENCY)
+}
+
+fn pull_retry_attempts() -> usize {
+    parse_positive_env_usize("RKFORGE_PULL_RETRIES", DEFAULT_PULL_RETRIES)
+}
+
+fn parse_positive_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+async fn remove_cached_blobs(paths: &[PathBuf]) -> anyhow::Result<()> {
+    for path in paths {
+        remove_cached_blob(path).await?;
+    }
+    Ok(())
+}
+
+async fn wait_for_layer_tasks(tasks: Vec<JoinHandle<anyhow::Result<()>>>) -> anyhow::Result<()> {
+    let results = futures::future::join_all(tasks).await;
+    for result in results {
+        result
+            .with_context(|| "Failed to join layer download task")?
+            .with_context(|| "Failed to pull and unpack layer")?;
+    }
+    Ok(())
+}
+
+async fn ensure_unpacked_layer_dirs(layers: &[PathBuf]) -> anyhow::Result<()> {
+    for layer in layers {
+        let metadata = tokio::fs::metadata(layer)
+            .await
+            .with_context(|| format!("Pulled layer is missing: {}", layer.display()))?;
+        if !metadata.is_dir() {
+            bail!(
+                "Pulled layer is not an unpacked directory: {}",
+                layer.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn pull_and_unpack_layer(
@@ -62,40 +163,42 @@ async fn pull_and_unpack_layer(
 
     pull_layer(client, image_ref, descriptor, &packed_blob_path, quiet).await?;
 
-    if no_cache && ultimate_blob_path.exists() {
-        let metadata = tokio::fs::symlink_metadata(&ultimate_blob_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to stat cached blob {}",
-                    ultimate_blob_path.display()
-                )
-            })?;
-        if metadata.file_type().is_dir() {
-            tokio::fs::remove_dir_all(&ultimate_blob_path)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to remove cached blob directory {}",
-                        ultimate_blob_path.display()
-                    )
-                })?;
-        } else {
-            tokio::fs::remove_file(&ultimate_blob_path)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to remove cached blob {}",
-                        ultimate_blob_path.display()
-                    )
-                })?;
-        }
+    if no_cache {
+        remove_cached_blob(&ultimate_blob_path).await?;
     }
 
     if no_cache || !ultimate_blob_path.exists() {
-        unpack_layer(descriptor, &packed_blob_path, &ultimate_blob_path).await?;
+        match unpack_layer(descriptor, &packed_blob_path, &ultimate_blob_path).await {
+            Ok(()) => {}
+            Err(err) => {
+                let _ = remove_cached_blob(&ultimate_blob_path).await;
+                return Err(err);
+            }
+        }
     }
 
+    Ok(())
+}
+
+async fn remove_cached_blob(path: &Path) -> anyhow::Result<()> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to stat cached blob {}", path.display()));
+        }
+    };
+
+    if metadata.file_type().is_dir() {
+        tokio::fs::remove_dir_all(path).await.with_context(|| {
+            format!("Failed to remove cached blob directory {}", path.display())
+        })?;
+    } else {
+        tokio::fs::remove_file(path)
+            .await
+            .with_context(|| format!("Failed to remove cached blob {}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -110,29 +213,175 @@ async fn pull_layer(
     let digest = descriptor.digest.split_digest()?;
 
     let progress_bar = new_progress_bar(descriptor.size as u64, digest, quiet);
+    let attempts = pull_retry_attempts();
 
-    let raw_layer_file = tokio::fs::File::create(dest)
+    for attempt in 1..=attempts {
+        match pull_layer_attempt(client, image_ref, descriptor, dest, &progress_bar).await {
+            Ok(()) => {
+                progress_bar.finish_with_message(format!("Downloaded layer {digest}"));
+                return Ok(());
+            }
+            Err(err) if attempt < attempts => {
+                let downloaded = downloaded_blob_size(dest).await.unwrap_or(0);
+                progress_bar.set_position(downloaded.min(descriptor.size as u64));
+                progress_bar.set_message(format!(
+                    "Retrying layer {digest} ({}/{attempts})",
+                    attempt + 1
+                ));
+                tracing::warn!(
+                    error = ?err,
+                    layer = %descriptor.digest,
+                    attempt,
+                    attempts,
+                    "layer pull attempt failed; retrying"
+                );
+                tokio::time::sleep(retry_delay(attempt)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("pull retry loop always returns")
+}
+
+async fn pull_layer_attempt(
+    client: &Client,
+    image_ref: &Reference,
+    descriptor: &OciDescriptor,
+    dest: &Path,
+    progress_bar: &ProgressBar,
+) -> anyhow::Result<()> {
+    let expected_size = descriptor.size as u64;
+    let mut offset = downloaded_blob_size(dest).await?;
+    if offset > expected_size {
+        remove_cached_blob(dest).await?;
+        offset = 0;
+    }
+
+    if offset == expected_size && expected_size != 0 {
+        match verify_downloaded_blob(dest, &descriptor.digest).await {
+            Ok(()) => {
+                progress_bar.set_position(expected_size);
+                return Ok(());
+            }
+            Err(err) => {
+                let _ = remove_cached_blob(dest).await;
+                return Err(err);
+            }
+        }
+    }
+
+    progress_bar.set_position(offset);
+    let response = client
+        .pull_blob_stream_partial(image_ref, descriptor, offset, None)
         .await
-        .with_context(|| format!("Failed to create layer file: {}", dest.display()))?;
-    let mut writer = LayerDownloadWrapper::new(raw_layer_file, progress_bar.clone());
+        .with_context(|| format!("Failed to pull layer blob {}", descriptor.digest))?;
 
-    client
-        .pull_blob(image_ref, descriptor, &mut writer)
+    let (stream, append) = match response {
+        BlobResponse::Full(stream) => {
+            if offset > 0 {
+                progress_bar.set_position(0);
+            }
+            (stream, false)
+        }
+        BlobResponse::Partial(stream) => (stream, true),
+    };
+
+    let file = if append {
+        tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dest)
+            .await
+            .with_context(|| format!("Failed to open layer file: {}", dest.display()))?
+    } else {
+        tokio::fs::File::create(dest)
+            .await
+            .with_context(|| format!("Failed to create layer file: {}", dest.display()))?
+    };
+    let mut writer = BufWriter::new(file);
+    let mut stream = stream.stream;
+
+    while let Some(bytes) = stream.next().await {
+        let bytes = bytes.with_context(|| format!("Failed to read layer {}", descriptor.digest))?;
+        writer
+            .write_all(&bytes)
+            .await
+            .with_context(|| format!("Failed to write layer file: {}", dest.display()))?;
+        progress_bar.inc(bytes.len() as u64);
+    }
+
+    writer
+        .flush()
         .await
-        .with_context(|| "Failed to pull layer blob of {}")?;
-
-    writer.flush().await?;
-    progress_bar.finish_with_message(format!("Downloaded layer {digest}"));
+        .with_context(|| format!("Failed to flush layer file: {}", dest.display()))?;
 
     let metadata = std::fs::metadata(dest)?;
-    if metadata.len() != descriptor.size as u64 {
-        anyhow::bail!(
-            "Downloaded layer size mismatch. Expected {}, but got {}",
-            descriptor.size,
+    if metadata.len() != expected_size {
+        bail!(
+            "Downloaded layer size mismatch for {}. Expected {}, but got {}",
+            descriptor.digest,
+            expected_size,
             metadata.len()
         );
     }
+    if let Err(err) = verify_downloaded_blob(dest, &descriptor.digest).await {
+        let _ = remove_cached_blob(dest).await;
+        return Err(err);
+    }
     Ok(())
+}
+
+async fn downloaded_blob_size(path: &Path) -> anyhow::Result<u64> {
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) => Ok(metadata.len()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(err) => {
+            Err(err).with_context(|| format!("Failed to stat layer download {}", path.display()))
+        }
+    }
+}
+
+async fn verify_downloaded_blob(path: &Path, digest: &str) -> anyhow::Result<()> {
+    let path = path.to_owned();
+    let digest = digest.to_string();
+    let digest_for_context = digest.clone();
+    tokio::task::spawn_blocking(move || verify_downloaded_blob_sync(&path, &digest))
+        .await?
+        .with_context(|| format!("Failed to verify downloaded layer {}", digest_for_context))
+}
+
+fn verify_downloaded_blob_sync(path: &Path, digest: &str) -> anyhow::Result<()> {
+    let expected = digest
+        .strip_prefix("sha256:")
+        .with_context(|| format!("Unsupported layer digest algorithm: {digest}"))?;
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open downloaded layer {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 128 * 1024];
+    loop {
+        let read = std::io::Read::read(&mut file, &mut buffer)
+            .with_context(|| format!("Failed to read downloaded layer {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        bail!(
+            "Downloaded layer digest mismatch for {}. Expected sha256:{}, got sha256:{}",
+            path.display(),
+            expected,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn retry_delay(attempt: usize) -> Duration {
+    let millis = 500_u64.saturating_mul(1_u64 << (attempt.saturating_sub(1).min(4)));
+    Duration::from_millis(millis.min(8_000))
 }
 
 async fn unpack_layer(
@@ -144,10 +393,47 @@ async fn unpack_layer(
 
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
+    let tmp_dst = temporary_unpack_path(&dst)?;
 
-    tokio::task::spawn_blocking(move || -> anyhow::Result<()> { media_type.unpack(&src, &dst) })
-        .await?
-        .with_context(|| format!("Failed to unpack layer {}", descriptor.digest))
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let unpack_result = media_type.unpack(&src, &tmp_dst);
+        match unpack_result {
+            Ok(()) => std::fs::rename(&tmp_dst, &dst)
+                .with_context(|| format!("Failed to move unpacked layer to {}", dst.display())),
+            Err(err) => {
+                remove_path_best_effort(&tmp_dst);
+                Err(err)
+            }
+        }
+    })
+    .await?
+    .with_context(|| format!("Failed to unpack layer {}", descriptor.digest))
+}
+
+fn temporary_unpack_path(dst: &Path) -> anyhow::Result<PathBuf> {
+    let parent = dst
+        .parent()
+        .with_context(|| format!("Blob path has no parent: {}", dst.display()))?;
+    let file_name = dst
+        .file_name()
+        .with_context(|| format!("Blob path has no file name: {}", dst.display()))?
+        .to_string_lossy();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    Ok(parent.join(format!(".{file_name}.tmp-{}-{nanos}", std::process::id())))
+}
+
+fn remove_path_best_effort(path: &Path) {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if metadata.file_type().is_dir() {
+        let _ = std::fs::remove_dir_all(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 fn new_progress_bar(total_size: u64, digest: impl AsRef<str>, quiet: bool) -> ProgressBar {
@@ -169,4 +455,61 @@ fn new_progress_bar(total_size: u64, digest: impl AsRef<str>, quiet: bool) -> Pr
         progress_bar.set_message(format!("Downloading layer {}", digest.as_ref()));
     }
     progress_bar
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ensure_unpacked_layer_dirs, parse_positive_env_usize, remove_cached_blobs, retry_delay,
+        wait_for_layer_tasks,
+    };
+
+    #[tokio::test]
+    async fn wait_for_layer_tasks_propagates_inner_error() {
+        let tasks = vec![tokio::spawn(async { anyhow::bail!("unpack failed") })];
+
+        let err = wait_for_layer_tasks(tasks).await.unwrap_err();
+
+        assert!(format!("{err:?}").contains("unpack failed"));
+    }
+
+    #[tokio::test]
+    async fn ensure_unpacked_layer_dirs_rejects_missing_layer() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_layer = temp_dir.path().join("missing-layer");
+
+        let err = ensure_unpacked_layer_dirs(&[missing_layer])
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Pulled layer is missing"));
+    }
+
+    #[tokio::test]
+    async fn remove_cached_blobs_removes_files_and_dirs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file = temp_dir.path().join("config");
+        let dir = temp_dir.path().join("layer");
+        std::fs::write(&file, "config").unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("file"), "layer").unwrap();
+
+        remove_cached_blobs(&[file.clone(), dir.clone()])
+            .await
+            .unwrap();
+
+        assert!(!file.exists());
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn retry_delay_is_capped() {
+        assert_eq!(retry_delay(1), std::time::Duration::from_millis(500));
+        assert_eq!(retry_delay(99), std::time::Duration::from_millis(8_000));
+    }
+
+    #[test]
+    fn parse_positive_env_usize_uses_default_for_invalid_values() {
+        assert_eq!(parse_positive_env_usize("__RKFORGE_TEST_MISSING", 7), 7);
+    }
 }

--- a/project/rkforge/src/pull/media.rs
+++ b/project/rkforge/src/pull/media.rs
@@ -13,11 +13,13 @@ impl MediaType {
 
         match self {
             MediaType::Tar => {
+                std::fs::create_dir_all(dst)?;
                 let tar_gz = std::fs::File::open(src)?;
                 let mut archive = tar::Archive::new(tar_gz);
                 archive.unpack(dst)?;
             }
             MediaType::TarGzip => {
+                std::fs::create_dir_all(dst)?;
                 let tar_gz = std::fs::File::open(src)?;
                 let decompressor = flate2::read::GzDecoder::new(tar_gz);
                 let mut archive = tar::Archive::new(decompressor);


### PR DESCRIPTION
- add Range support for distribution blob downloads on filesystem and S3 storage
- resume rkforge layer downloads with retries and partial blob append
- verify downloaded layer size/digest and clean up failed pull/unpack artifacts
- propagate layer task failures before writing pull metadata